### PR TITLE
Fix #7 Package Diagram

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.core/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: Core
 Bundle-SymbolicName: org.eclipse.papyrus.umllight.core;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Activator: org.eclipse.papyrus.umllight.core.internal.Activator
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.uml.diagram.common;bundle-version="3.2.0",
  org.eclipse.papyrus.infra.architecture;bundle-version="2.0.0",
  org.eclipse.papyrus.uml.service.types;bundle-version="[4.0.0,5.0.0)",

--- a/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
@@ -7,5 +7,13 @@
             path="resource/architecture/UMLLight.architecture">
       </model>
    </extension>
-
+   <extension
+         point="org.eclipse.papyrus.infra.newchild">
+      <menuCreationModel
+            model="resource/creationmenu/UMLLightNewChild.creationmenumodel">
+      </menuCreationModel>
+      <menuCreationModel
+            model="resource/creationmenu/UMLLightNewRelationship.creationmenumodel">
+      </menuCreationModel>
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
@@ -92,6 +92,7 @@
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_m9soMNuDEeighZmUYRFaeg" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Element_ContainmentEdge"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_k1YYMNuAEeiz8qHnQ39r-A" permit="false"/>
       <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/palette/UMLLightClassDiagram.paletteconfiguration#/"/>
+      <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.diagram.clazz/model/PapyrusUMLClassDiagram.paletteconfiguration#/"/>
     </representationKinds>
     <metamodel xmi:type="ecore:EPackage" href="http://www.eclipse.org/uml2/5.0.0/UML#/"/>
   </contexts>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
@@ -3,7 +3,7 @@
   <stakeholders xmi:type="architecture:Stakeholder" xmi:id="_ysbS4NOxEeiTpIcrXWETSQ" id="org.eclipse.papyrus.umllight.modeler" name="UML Light Modeler" description="a stakeholder in charge of UML modeling" concerns="__JaYANOxEeiTpIcrXWETSQ"/>
   <concerns xmi:type="architecture:Concern" xmi:id="__JaYANOxEeiTpIcrXWETSQ" id="org.eclipse.papyrus.umllight.concern.basic" name="Basic UML Modeling" description="The concern of UML Light modeling"/>
   <contexts xmi:type="architecture:ArchitectureDescriptionLanguage" xmi:id="_H1R78NOyEeiTpIcrXWETSQ" id="org.eclipse.papyrus.umllight" name="UML Light" description="UML Light, a simplified subset of UML" icon="platform:/plugin/org.eclipse.papyrus.umllight.core/icons/papyrus.png" defaultViewpoints="_cXaRUNO0Eei48-PIi9TeBw" creationCommandClass="org.eclipse.papyrus.umllight.core.command.CreateUMLLightCommand">
-    <viewpoints xmi:type="architecture:ArchitectureViewpoint" xmi:id="_cXaRUNO0Eei48-PIi9TeBw" id="org.eclipse.papyrus.umllight.viewpoint.basic" name="UML Light" description="UML Light Viewpoint" icon="platform:/plugin/org.eclipse.papyrus.umllight.core/icons/papyrus.png" concerns="__JaYANOxEeiTpIcrXWETSQ" representationKinds="_m8PFgNO1Eei48-PIi9TeBw"/>
+    <viewpoints xmi:type="architecture:ArchitectureViewpoint" xmi:id="_cXaRUNO0Eei48-PIi9TeBw" id="org.eclipse.papyrus.umllight.viewpoint.basic" name="UML Light" description="UML Light Viewpoint" icon="platform:/plugin/org.eclipse.papyrus.umllight.core/icons/papyrus.png" concerns="__JaYANOxEeiTpIcrXWETSQ" representationKinds="_m8PFgNO1Eei48-PIi9TeBw _KQVFMNbrEeimr-yFskxXQQ"/>
     <elementTypes xmi:type="elementtypesconfigurations:ElementTypeSetConfiguration" href="platform:/plugin/org.eclipse.papyrus.infra.emf/model/infra-emf.elementtypesconfigurations#_rWI4YHPzEeSnGJwaJWHCSg"/>
     <elementTypes xmi:type="elementtypesconfigurations:ElementTypeSetConfiguration" href="platform:/plugin/org.eclipse.papyrus.infra.gmfdiag.common/model/notation.elementtypesconfigurations#_ScP1oFYCEeS0WsAAtVmToA"/>
     <elementTypes xmi:type="elementtypesconfigurations:ElementTypeSetConfiguration" href="platform:/plugin/org.eclipse.papyrus.infra.gmfdiag.common/model/gmfdiag-common.elementtypesconfigurations#_rWI4YHPzEeSnGJwaJWHCSg"/>
@@ -54,6 +54,30 @@
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_rhJHkNtqEeiKL9qM2SXqag" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_ConstrainedElementEdge"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_Gf8QUNtrEeiKL9qM2SXqag" permit="true" elementTypeID="org.eclipse.papyrus.umldi.EnumerationLiteral_LiteralLabel"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_toFl8NtqEeiKL9qM2SXqag" permit="false"/>
+      <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/palette/UMLLightClassDiagram.paletteconfiguration#/"/>
+    </representationKinds>
+    <representationKinds xmi:type="gmfdiagrepresentation:PapyrusDiagram" xmi:id="_KQVFMNbrEeimr-yFskxXQQ" id="org.eclipse.papyrus.umllight.diagram.package" name=" Light Package Diagram" description="Simplified version of the package diagram" icon="platform:/plugin/org.eclipse.papyrus.infra.viewpoints.policy/icons/Diagram_Package.gif" concerns="__JaYANOxEeiTpIcrXWETSQ" implementationID="PapyrusUMLClassDiagram" customStyle="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css" creationCommandClass="org.eclipse.papyrus.uml.diagram.clazz.CreateClassDiagramCommand">
+      <modelRules xmi:type="representation:ModelRule" xmi:id="_KQVFMdbrEeimr-yFskxXQQ" permit="true" elementMultiplicity="1" multiplicity="-1">
+        <element xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Package"/>
+      </modelRules>
+      <owningRules xmi:type="representation:OwningRule" xmi:id="_KQVFMtbrEeimr-yFskxXQQ" permit="true" multiplicity="-1">
+        <element xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Package"/>
+      </owningRules>
+      <childRules xmi:type="gmfdiagrepresentation:ChildRule" xmi:id="_KQVFM9brEeimr-yFskxXQQ" permit="true"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_gNzzsNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.package"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qVJQENbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.model"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_u6fqkNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.profile"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qajUgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.comment"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qfISgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.constraint"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qj3BgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.dependency"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_2JgO8NbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.packageimport"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_5aRcINbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.containmentlink"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_5fq5gNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.contextlink"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_BSHiINbtEeimr-yFskxXQQ" permit="true" element="clazz.tool.link"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_HXXpINbtEeimr-yFskxXQQ" permit="true" element="clazz.tool.profileapplication"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_MRfZwNbtEeimr-yFskxXQQ" permit="false" element="clazz.tool.*"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_PvQhINbtEeimr-yFskxXQQ" permit="false" element="create*"/>
+      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_ToIQINbtEeimr-yFskxXQQ" permit="true"/>
       <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/palette/UMLLightClassDiagram.paletteconfiguration#/"/>
     </representationKinds>
     <metamodel xmi:type="ecore:EPackage" href="http://www.eclipse.org/uml2/5.0.0/UML#/"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
@@ -66,7 +66,6 @@
       <childRules xmi:type="gmfdiagrepresentation:ChildRule" xmi:id="_KQVFM9brEeimr-yFskxXQQ" permit="true"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_gNzzsNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.package"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qVJQENbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.model"/>
-      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_u6fqkNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.profile"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qajUgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.comment"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qfISgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.constraint"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qj3BgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.dependency"/>
@@ -74,10 +73,24 @@
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_5aRcINbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.containmentlink"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_5fq5gNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.contextlink"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_BSHiINbtEeimr-yFskxXQQ" permit="true" element="clazz.tool.link"/>
-      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_HXXpINbtEeimr-yFskxXQQ" permit="true" element="clazz.tool.profileapplication"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_MRfZwNbtEeimr-yFskxXQQ" permit="false" element="clazz.tool.*"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_PvQhINbtEeimr-yFskxXQQ" permit="false" element="create*"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_ToIQINbtEeimr-yFskxXQQ" permit="true"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_ZyzbkNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Package_Shape"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_e7PfkNuBEeie-v_cAFusrA" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Package_Shape_CN"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_e7PfkduBEeie-v_cAFusrA" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Model_Shape"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_eDVcoNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Model_Shape_CN"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_ePAhINuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Comment_Shape"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_0483kNuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Comment_Shape_CN"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_kzBV0NuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_PackagedElementShape"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_k5lQ0NuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_PackagedElementShape_CN"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_esYZoNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.PackageImport_Edge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_j5bGQNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Dependency_Edge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_AOEVsNuDEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Comment_AnnotatedElementEdge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_YqVFsNuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_ContextEdge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_ifUN0NuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_ConstrainedElementEdge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_m9soMNuDEeighZmUYRFaeg" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Element_ContainmentEdge"/>
+      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_k1YYMNuAEeiz8qHnQ39r-A" permit="false"/>
       <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/palette/UMLLightClassDiagram.paletteconfiguration#/"/>
     </representationKinds>
     <metamodel xmi:type="ecore:EPackage" href="http://www.eclipse.org/uml2/5.0.0/UML#/"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
@@ -65,7 +65,6 @@
       </owningRules>
       <childRules xmi:type="gmfdiagrepresentation:ChildRule" xmi:id="_KQVFM9brEeimr-yFskxXQQ" permit="true"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_gNzzsNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.package"/>
-      <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qVJQENbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.model"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qajUgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.comment"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qfISgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.constraint"/>
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_qj3BgNbsEeimr-yFskxXQQ" permit="true" element="clazz.tool.dependency"/>
@@ -78,8 +77,6 @@
       <paletteRules xmi:type="gmfdiagrepresentation:PaletteRule" xmi:id="_ToIQINbtEeimr-yFskxXQQ" permit="true"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_ZyzbkNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Package_Shape"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_e7PfkNuBEeie-v_cAFusrA" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Package_Shape_CN"/>
-      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_e7PfkduBEeie-v_cAFusrA" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Model_Shape"/>
-      <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_eDVcoNuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Model_Shape_CN"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_ePAhINuAEeiz8qHnQ39r-A" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Comment_Shape"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_0483kNuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Comment_Shape_CN"/>
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_kzBV0NuCEeiwaPLBgLi07Q" permit="true" elementTypeID="org.eclipse.papyrus.umldi.Constraint_PackagedElementShape"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
@@ -45,9 +45,6 @@
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralUnlimitedNatural" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralUnlimitedNatural"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Model" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Model"/>
-  </menu>
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="OpaqueExpression" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.OpaqueExpression"/>
   </menu>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ElementCreationMenuModel:Folder xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ElementCreationMenuModel="http://www.eclipse.org/papyrus/infra/newchild/elementcreationmenumodel" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.2" label="New Child">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Actor" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Actor"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Class" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Class"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Comment" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Comment"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Constraint" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Constraint"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="DataType" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.DataType"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Enumeration" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Enumeration"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="EnumerationLiteral" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.EnumerationLiteral"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Expression" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Expression"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Interface" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Interface"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralBoolean" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralBoolean"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralInteger">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralInteger"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralNull" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralNull"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralReal" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralReal"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralString" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralString"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="LiteralUnlimitedNatural" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.LiteralUnlimitedNatural"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Model" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Model"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="OpaqueExpression" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.OpaqueExpression"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Operation" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Operation"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Package" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Package"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Parameter" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Parameter"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="PrimitiveType" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.PrimitiveType"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Profile" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Profile"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Property" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Property"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="StringExpression" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.StringExpression"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="UseCase" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.UseCase"/>
+  </menu>
+</ElementCreationMenuModel:Folder>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
@@ -63,14 +63,8 @@
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="PrimitiveType" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.PrimitiveType"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Profile" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Profile"/>
-  </menu>
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Property" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Property"/>
-  </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="StringExpression" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.StringExpression"/>
   </menu>
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="UseCase" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.UseCase"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewRelationship.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewRelationship.creationmenumodel
@@ -9,9 +9,6 @@
   <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Dependency" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Dependency"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="ElementImport" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.ElementImport"/>
-  </menu>
   <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Extend" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Extend"/>
   </menu>
@@ -26,14 +23,5 @@
   </menu>
   <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="PackageImport" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.PackageImport"/>
-  </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="ProfileApplication" visible="false" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.ProfileApplication"/>
-  </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Realization" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Realization"/>
-  </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Usage" displayAllRoles="false">
-    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Usage"/>
   </menu>
 </ElementCreationMenuModel:Folder>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewRelationship.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewRelationship.creationmenumodel
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ElementCreationMenuModel:Folder xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ElementCreationMenuModel="http://www.eclipse.org/papyrus/infra/newchild/elementcreationmenumodel" xmlns:elementtypesconfigurations="http://www.eclipse.org/papyrus/infra/elementtypesconfigurations/1.2" label="New Relationship">
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Abstraction" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Abstraction"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Association" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Association"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Dependency" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Dependency"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="ElementImport" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.ElementImport"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Extend" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Extend"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Generalization" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Generalization"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Include" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Include"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="InterfaceRealization" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.InterfaceRealization"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="PackageImport" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.PackageImport"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="ProfileApplication" visible="false" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.ProfileApplication"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Realization" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Realization"/>
+  </menu>
+  <menu xsi:type="ElementCreationMenuModel:CreateRelationshipMenu" label="Usage" displayAllRoles="false">
+    <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Usage"/>
+  </menu>
+</ElementCreationMenuModel:Folder>

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/Activator.java
@@ -12,20 +12,20 @@
 
 package org.eclipse.papyrus.umllight.core.internal;
 
-import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.core.runtime.Plugin;
 import org.osgi.framework.BundleContext;
 
 /**
  * The activator class controls the plug-in life cycle
  */
-public class Activator extends AbstractUIPlugin {
+public class Activator extends Plugin {
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.papyrus.umllight.core"; //$NON-NLS-1$
 
 	// The shared instance
 	private static Activator plugin;
-	
+
 	/**
 	 * The constructor
 	 */
@@ -34,7 +34,9 @@ public class Activator extends AbstractUIPlugin {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+	 * 
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
+	 * BundleContext)
 	 */
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
@@ -43,7 +45,9 @@ public class Activator extends AbstractUIPlugin {
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 * 
+	 * @see
+	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
 	 */
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;

--- a/plugins/org.eclipse.papyrus.umllight.ui/.classpath
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/org.eclipse.papyrus.umllight.ui/.gitignore
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/target/

--- a/plugins/org.eclipse.papyrus.umllight.ui/.project
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.papyrus.umllight.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: UML Light UI
+Bundle-SymbolicName: org.eclipse.papyrus.umllight.ui;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Bundle-Activator: org.eclipse.papyrus.umllight.ui.internal.Activator
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.ui,
+ org.eclipse.papyrus.umllight.core;bundle-version="0.0.1",
+ org.eclipse.papyrus.infra.newchild;bundle-version="[4.0.0,5.0.0)"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.papyrus.umllight.core
+Bundle-ActivationPolicy: lazy
+Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true

--- a/plugins/org.eclipse.papyrus.umllight.ui/build.properties
+++ b/plugins/org.eclipse.papyrus.umllight.ui/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.ui.startup">
+      <startup
+            class="org.eclipse.papyrus.umllight.ui.internal.newchild.CreationMenuCleaner$Startup">
+      </startup>
+   </extension>
+</plugin>

--- a/plugins/org.eclipse.papyrus.umllight.ui/pom.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.papyrus.umllight</groupId>
+		<artifactId>org.eclipse.papyrus.umllight.parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.papyrus.umllight.ui</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.umllight.ui.internal;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.papyrus.umllight.ui.internal.newchild.CreationMenuCleaner;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.ui.progress.UIJob;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ */
+public class Activator extends AbstractUIPlugin {
+
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.eclipse.papyrus.umllight.ui"; //$NON-NLS-1$
+
+	// The shared instance
+	private static Activator plugin;
+
+	/**
+	 * Initializes me.
+	 */
+	public Activator() {
+		super();
+	}
+
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+
+		plugin = this;
+
+		configureCreationMenus();
+	}
+
+	public void stop(BundleContext context) throws Exception {
+		plugin = null;
+
+		super.stop(context);
+	}
+
+	/**
+	 * Obtains the shared instance.
+	 *
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
+
+	private void configureCreationMenus() {
+		// Do this on the UI thread because that's the context in which the creation
+		// menu registry is generally accessed
+		new UIJob("Initializing creation menus") {
+
+			@Override
+			public IStatus runInUIThread(IProgressMonitor monitor) {
+				return CreationMenuCleaner.clean();
+			}
+		}.schedule();
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/newchild/CreationMenuCleaner.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/newchild/CreationMenuCleaner.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2016, 2018 EclipseSource Services GmbH, Christian W. Damus, and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   Martin Fleck (EclipseSource) - Initial API and implementation
+ *   Christian W. Damus - adaptation for UML Light
+ */
+package org.eclipse.papyrus.umllight.ui.internal.newchild;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.osgi.util.NLS;
+import org.eclipse.papyrus.infra.newchild.CreationMenuRegistry;
+import org.eclipse.papyrus.infra.newchild.elementcreationmenumodel.Folder;
+import org.eclipse.papyrus.umllight.ui.internal.Activator;
+import org.eclipse.ui.IStartup;
+
+/**
+ * Cleans the creation menu.
+ */
+public final class CreationMenuCleaner {
+
+	private static final String UML_NEW_CHILD_MENU = "/resource/UML.creationmenumodel"; //$NON-NLS-1$
+	private static final String UML_NEW_RELATIONSHIP_MENU = "/resource/UMLEdges.creationmenumodel"; //$NON-NLS-1$
+
+	private static final List<String> DEACTIVATED_CHILD_MENUS = Arrays.asList(//
+			UML_NEW_CHILD_MENU, //
+			UML_NEW_RELATIONSHIP_MENU //
+	);
+
+	/**
+	 * Not instantiable by clients.
+	 */
+	private CreationMenuCleaner() {
+		super();
+	}
+
+	/**
+	 * Cleans the creation menu.
+	 * 
+	 * @return status of the clean operation, with details of any problems
+	 */
+	public static IStatus clean() {
+		Set<String> toDisable = new HashSet<>(DEACTIVATED_CHILD_MENUS);
+
+		CreationMenuRegistry registry = CreationMenuRegistry.getInstance();
+		for (Folder folder : registry.getRootFolder()) {
+			for (String childMenuPath : DEACTIVATED_CHILD_MENUS) {
+				if (folder.eResource().getURI().toString().endsWith(childMenuPath)) {
+					toDisable.remove(childMenuPath);
+
+					if (registry.getCreationMenuVisibility(folder)) {
+						registry.setCreationMenuVisibility(folder, false);
+					}
+				}
+			}
+		}
+
+		if (!toDisable.isEmpty()) {
+			return new Status(IStatus.WARNING, Activator.PLUGIN_ID,
+					NLS.bind("Some new-child menus not disabled: {0}", toDisable));
+		}
+
+		return Status.OK_STATUS;
+	}
+
+	//
+	// Nested types
+	//
+
+	/**
+	 * An early startup hook that cleans the creation menu registry.
+	 */
+	public static class Startup implements IStartup {
+		@Override
+		public void earlyStartup() {
+			// Nothing really to do but kick the activator
+			Activator.getDefault();
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,7 @@
 	<name>org.eclipse.papyrus.umllight.parent</name>
 	<description>A Papyrus DSML for UML Modeling</description>
 	<inceptionYear>2018</inceptionYear>
-	<modules>
-		<module>plugins/org.eclipse.papyrus.umllight.core</module>
-		<module>plugins/org.eclipse.papyrus.umllight.ui.simplification</module>
-		<module>releng</module>
-	</modules>
+
 	<properties>
 		<!-- plugins versions -->
 		<!-- use 'mvn versions:display-plugin-updates' to check for the latest -->
@@ -27,6 +23,14 @@
 		<!-- release | nightly -->
 		<target.version>0.0.1-SNAPSHOT</target.version>
 	</properties>
+
+	<modules>
+		<module>plugins/org.eclipse.papyrus.umllight.core</module>
+		<module>plugins/org.eclipse.papyrus.umllight.ui.simplification</module>
+		<module>plugins/org.eclipse.papyrus.umllight.ui</module>
+		<module>releng</module>
+	</modules>
+
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/releng/org.eclipse.papyrus.umllight.feature/feature.xml
+++ b/releng/org.eclipse.papyrus.umllight.feature/feature.xml
@@ -30,4 +30,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.papyrus.umllight.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
Define a _Package Diagram_ as a refinement of the _Class Diagram_, essentially just selecting a subset of what can be shown in the latter.

However, **more importantly**, add initial creation-menu models for the _UML Light_ dialect:
- New Child menu
- New Relationship menu
- UI bundle with an activator that disables the _Papyrus UML_ new-child extensions to leave only the _UML Light_ menus
  - for now, at least, this requires a UI start-up hook because otherwise this bundle wouldn't be activated

It is expected that these creation menu models will likely need further refinement according to the various specific issues scheduled in this milestone.

I also include some Eclipse project metadata files to enable working on the upper layers of the Maven module structure in the workspace.