### PR TITLE
Fix #30 Use case shape replication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.source>1.8</java.source>
 		<java.target>1.8</java.target>
-		<target.eclipseversion>photon</target.eclipseversion>
-		<!-- photon | oxygen -->
-		<target.branch>release</target.branch>
+		<!-- r2018-12 | photon | oxygen -->
+		<target.eclipseversion>r2018-12</target.eclipseversion>
 		<!-- release | nightly -->
+		<target.branch>nightly</target.branch>
 		<target.version>0.0.1-SNAPSHOT</target.version>
 	</properties>
 

--- a/targetplatforms/r2018-12-nightly.target
+++ b/targetplatforms/r2018-12-nightly.target
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="UML Light Target Platform - 2018-12 Nightly" sequenceNumber="1541015386">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.platform.feature.group" version="4.10.0.v20181010-1800"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.10.0.v20181010-1800"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.10.0.v20181010-1800"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.16.0.v20181010-1800"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.100.v20180822-1357"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.200.v20180922-1751"/>
+      <unit id="org.eclipse.draw2d" version="3.10.100.201606061308"/>
+      <unit id="org.eclipse.gef" version="3.11.0.201606061308"/>
+      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.9.1.v20181013-0521"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.15.0.v20180905-1732"/>
+      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.15.0.v20180722-1116"/>
+      <unit id="org.eclipse.emf.validation.sdk.feature.group" version="1.12.0.201805030717"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.12.0.201805140824"/>
+      <unit id="org.eclipse.emf.workspace.feature.group" version="1.12.0.201805140824"/>
+      <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="1.12.0.201805221301"/>
+      <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.12.0.201806010809"/>
+      <unit id="org.eclipse.uml2.sdk.feature.group" version="5.4.2.v20181008-1339"/>
+      <repository id="eclipse-photon" location="http://download.eclipse.org/releases/2018-12/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.egit.feature.group" version="5.1.3.201810200350-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.1.3.201810200350-r"/>
+      <repository id="egit" location="http://download.eclipse.org/egit/updates-5.1.3"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+      <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
+      <unit id="com.google.inject" version="3.0.0.v201605172100"/>
+      <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
+      <unit id="com.google.guava.source" version="21.0.0.v20170206-1425"/>
+      <unit id="javaewah" version="1.1.6.v20160919-1400"/>
+      <unit id="org.apache.commons.compress" version="1.15.0.v20180119-1613"/>
+      <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+      <unit id="org.kohsuke.args4j" version="2.33.0.v20160323-2218"/>
+      <unit id="org.mockito" version="1.9.5.v201605172210"/>
+      <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+      <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
+      <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
+      <unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
+      <unit id="org.objenesis" version="1.0.0.v201505121915"/>
+      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.papyrus.sdk.feature.feature.group" version="4.2.0.201810311902"/>
+      <unit id="org.eclipse.papyrus.infra.gmfdiag.feature.feature.group" version="3.0.0.201810311902"/>
+      <unit id="org.eclipse.papyrus.infra.services.feature.feature.group" version="3.0.0.201810311902"/>
+      <unit id="org.eclipse.papyrus.views.properties.toolsmiths" version="2.0.2.201810311924"/>
+      <unit id="org.eclipse.papyrus.uml.assistants.feature.feature.group" version="4.0.0.201810311924"/>
+      <unit id="org.eclipse.papyrus.toolsmiths.feature.feature.group" version="1.2.0.201810311924"/>
+      <repository id="papyrus" location="http://download.eclipse.org/modeling/mdt/papyrus/updates/nightly/master"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.papyrus.compare.feature.feature.group" version="0.7.0.201810232321"/>
+      <repository location="http://download.eclipse.org/modeling/mdt/papyrus/components/compare/updates/nightly/latest/"/>
+    </location>
+  </locations>
+</target>

--- a/targetplatforms/r2018-12-nightly.tpd
+++ b/targetplatforms/r2018-12-nightly.tpd
@@ -1,0 +1,58 @@
+target "UML Light Target Platform - 2018-12 Nightly" with source requirements
+
+location "http://download.eclipse.org/releases/2018-12/" eclipse-photon {
+	org.eclipse.platform.feature.group
+	org.eclipse.sdk.feature.group
+	org.eclipse.rcp.feature.group
+	org.eclipse.jdt.feature.group
+	org.eclipse.equinox.p2.discovery.feature.feature.group
+	org.eclipse.equinox.executable.feature.group
+	org.eclipse.draw2d
+	org.eclipse.gef
+	org.eclipse.m2m.qvt.oml.sdk.feature.group
+	org.eclipse.emf.sdk.feature.group
+	org.eclipse.xsd.sdk.feature.group
+	org.eclipse.emf.validation.sdk.feature.group
+	org.eclipse.emf.transaction.sdk.feature.group
+	org.eclipse.emf.workspace.feature.group
+	org.eclipse.gmf.runtime.notation.sdk.feature.group
+	org.eclipse.gmf.runtime.sdk.feature.group
+	org.eclipse.uml2.sdk.feature.group
+}
+
+location "http://download.eclipse.org/egit/updates-5.1.3" egit {
+	org.eclipse.egit.feature.group
+	org.eclipse.jgit.feature.group
+}
+
+
+location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository/" {
+	org.apache.commons.io
+	org.apache.commons.io.source
+	com.google.inject
+	com.google.guava [21.0.0,22.0.0)
+	com.google.guava.source [21.0.0,22.0.0)
+	javaewah
+	org.apache.commons.compress
+	org.apache.commons.lang
+	org.kohsuke.args4j
+	org.mockito [1.9.0,2.0.0)
+	org.hamcrest
+	org.hamcrest.library
+	org.hamcrest.integration
+	org.hamcrest.text
+	org.objenesis [1.0.0,2.0.0)
+}
+
+location papyrus "http://download.eclipse.org/modeling/mdt/papyrus/updates/nightly/master" {
+	org.eclipse.papyrus.sdk.feature.feature.group
+	org.eclipse.papyrus.infra.gmfdiag.feature.feature.group
+	org.eclipse.papyrus.infra.services.feature.feature.group
+	org.eclipse.papyrus.views.properties.toolsmiths
+	org.eclipse.papyrus.uml.assistants.feature.feature.group
+	org.eclipse.papyrus.toolsmiths.feature.feature.group
+}
+// Using nightly version of Papyrus compare for now because the latest stable version has Photon incompatibilities 
+location "http://download.eclipse.org/modeling/mdt/papyrus/components/compare/updates/nightly/latest/" {
+	org.eclipse.papyrus.compare.feature.feature.group 
+}


### PR DESCRIPTION
Update the target platform to take Papyrus nightly build with fix for use case shape replication in the diagram.

**Note** that this adds a new TPD for nightly builds of the 2012-18 release.  The Photon release TPD remains as is.