### PR TITLE
Fix #16 Hide tables

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.classpath
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.gitignore
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/target/

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.project
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.papyrus.umllight.ui.simplification.transforms</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: UML Light UI Simplification Transforms
+Bundle-SymbolicName: org.eclipse.papyrus.umllight.ui.simplification.transforms;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Bundle-Activator: org.eclipse.papyrus.umllight.ui.simplification.transforms.internal.Activator
+Require-Bundle: org.eclipse.osgi,
+ org.eclipse.equinox.transforms.xslt
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.papyrus.umllight.core
+Bundle-ActivationPolicy: lazy
+Export-Package: org.eclipse.papyrus.umllight.ui.simplification.transforms.internal;x-internal:=true

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/build.properties
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               transforms/

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/pom.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.papyrus.umllight</groupId>
+		<artifactId>org.eclipse.papyrus.umllight.parent</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.papyrus.umllight.ui.simplification.transforms</artifactId>
+	<packaging>eclipse-plugin</packaging>
+</project>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/src/org/eclipse/papyrus/umllight/ui/simplification/transforms/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/src/org/eclipse/papyrus/umllight/ui/simplification/transforms/internal/Activator.java
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+
+package org.eclipse.papyrus.umllight.ui.simplification.transforms.internal;
+
+import java.net.URL;
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ */
+public class Activator implements BundleActivator {
+
+	private ServiceRegistration<URL> transformURLReg;
+
+	/**
+	 * Initializes me.
+	 */
+	public Activator() {
+		super();
+	}
+
+	public void start(BundleContext context) throws Exception {
+		Hashtable<String, Object> properties = new Hashtable<>();
+		properties.put("equinox.transformerType", "xslt"); //$NON-NLS-1$ //$NON-NLS-2$
+		transformURLReg = context.registerService(URL.class, context.getBundle().getEntry("/transforms/transforms.csv"), //$NON-NLS-1$
+				properties);
+	}
+
+	public void stop(BundleContext context) throws Exception {
+		if (transformURLReg != null) {
+			transformURLReg.unregister();
+			transformURLReg = null;
+		}
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/nattable.xslt
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/nattable.xslt
@@ -1,0 +1,12 @@
+ <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+     <!-- Suppress the contribution of the 'New Table' menu in the Model Explorer -->
+     <xsl:template match="extension[@id='papyrus.table.menuspapyrus.table.menu']">
+     </xsl:template>
+     
+     <!-- Everything else -->
+     <xsl:template match="node()|@*">
+         <xsl:copy>
+             <xsl:apply-templates select="node()|@*"/>
+         </xsl:copy>
+     </xsl:template>
+ </xsl:stylesheet>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/transforms.csv
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/transforms.csv
@@ -1,0 +1,2 @@
+#Bundle ID regex, Resource Path regex, resource path
+org\.eclipse\.papyrus\.infra\.nattable\.common,plugin\.xml,/transforms/nattable.xslt

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/plugin.xml
@@ -538,6 +538,15 @@
          <hiddenToolBarItem
                id="org.eclipse.papyrus.infra.viewpoints.policy.toolbar.diagrams">
          </hiddenToolBarItem>
+         <hiddenToolBarItem
+               id="org.eclipse.papyrus.infra.nattable.toolbar.createnattable">
+         </hiddenToolBarItem>
+         <hiddenToolBarItem
+               id="org.eclipse.papyrus.infra.viewpoints.policy.toolbar.tables.command">
+         </hiddenToolBarItem>
+         <hiddenToolBarItem
+               id="org.eclipse.papyrus.infra.nattable.createFromCatalog.command">
+         </hiddenToolBarItem>
       </perspectiveExtension>
    </extension>
  

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
 	<modules>
 		<module>plugins/org.eclipse.papyrus.umllight.core</module>
+		<module>plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms</module>
 		<module>plugins/org.eclipse.papyrus.umllight.ui.simplification</module>
 		<module>plugins/org.eclipse.papyrus.umllight.ui</module>
 		<module>releng</module>

--- a/releng/org.eclipse.papyrus.umllight.product/papyrusUMLLight.product
+++ b/releng/org.eclipse.papyrus.umllight.product/papyrusUMLLight.product
@@ -142,10 +142,13 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.equinox.transforms.xslt" autoStart="true" startLevel="1" />
+      <plugin id="org.eclipse.papyrus.umllight.ui.simplification.transforms" autoStart="true" startLevel="1" />
+      <property name="osgi.framework.extensions" value="org.eclipse.equinox.transforms.hook" />
    </configurations>
 
    <repositories>
-      <repository location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/photon" enabled="true" />
+      <repository location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2018-09" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/releng/org.eclipse.papyrus.umllight.rcp.feature/feature.xml
+++ b/releng/org.eclipse.papyrus.umllight.rcp.feature/feature.xml
@@ -23,4 +23,25 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.papyrus.umllight.ui.simplification.transforms"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.transforms.hook"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.transforms.xslt"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/targetplatforms/r2018-12-nightly.target
+++ b/targetplatforms/r2018-12-nightly.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="UML Light Target Platform - 2018-12 Nightly" sequenceNumber="1541465627">
+<target name="UML Light Target Platform - 2018-12 Nightly" sequenceNumber="1541519008">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.platform.feature.group" version="4.9.0.v20180906-1121"/>
@@ -21,6 +21,8 @@
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="1.12.0.201805221301"/>
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.12.0.201806010809"/>
       <unit id="org.eclipse.uml2.sdk.feature.group" version="5.4.1.v20180903-1400"/>
+      <unit id="org.eclipse.equinox.transforms.hook" version="1.2.200.v20180827-1235"/>
+      <unit id="org.eclipse.equinox.transforms.xslt" version="1.0.500.v20180827-1235"/>
       <repository id="eclipse-platform" location="http://download.eclipse.org/releases/2018-09/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/targetplatforms/r2018-12-nightly.tpd
+++ b/targetplatforms/r2018-12-nightly.tpd
@@ -18,6 +18,8 @@ location "http://download.eclipse.org/releases/2018-09/" eclipse-platform {
 	org.eclipse.gmf.runtime.notation.sdk.feature.group
 	org.eclipse.gmf.runtime.sdk.feature.group
 	org.eclipse.uml2.sdk.feature.group
+	org.eclipse.equinox.transforms.hook
+	org.eclipse.equinox.transforms.xslt
 }
 
 location "http://download.eclipse.org/egit/updates-5.1.3" egit {


### PR DESCRIPTION
Hide the toolbar items for table creation.

Deploy an Equinox transform to remove the **New Table** menu action in the model explorer.  This heavyweight approach is required because activities cannot be used to hide this menu.  Debugging shows that Eclipse Platform is not consulting the activity manager to determine whether this sub-menu of the context menu should be shown or not.

## Testing Note

Testing the Equinox transform in a run-time workbench is difficult, as it requires individual configuration of start levels and auto-start for bundles (as configured in the product definition).  Unfortunately, PDE cannot use the product definition for this because the product selection in the launch configuration is the product *extension* in the RCP bundle, not the *product definition* that is used only by the build.  So, the best way to test this is to run a Maven build with the `product` profile and run the product built for your platform:

```bash
    $ mvn -Pproduct clean verify
    $ cd releng/org.eclipse.papyrus.umllight.product/target/products/org.eclipse.papyrus.umllight.product
    $ open macosx/cocoa/x86_64/papyrus-umllight.app
```