### PR TITLE
Fix #14 New child menu for interactions

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.core/META-INF/MANIFEST.MF
@@ -18,6 +18,8 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
-Export-Package: org.eclipse.papyrus.umllight.core.internal,
+Export-Package: org.eclipse.papyrus.umllight.core.command,
+ org.eclipse.papyrus.umllight.core.internal,
+ org.eclipse.papyrus.umllight.core.internal.advice;x-internal:=true,
  org.eclipse.papyrus.umllight.core.internal.provider;x-internal:=true
 Import-Package: com.google.common.collect;version="21.0.0"

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/types/UMLLightDI.elementtypesconfigurations
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/types/UMLLightDI.elementtypesconfigurations
@@ -4,4 +4,7 @@
     <specializedTypes xmi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Class"/>
     <specializedTypes xmi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/umldi.elementtypesconfigurations#org.eclipse.papyrus.umldi.Classifier_SubjectShape"/>
   </elementTypeConfigurations>
+  <adviceBindingsConfigurations xmi:type="elementtypesconfigurations:AdviceBindingConfiguration" xmi:id="_WTm9EOaSEeiDlPiDRVMD0w" description="Advice to suppress creation of features and other class content in an Interaction." identifier="org.eclipse.papyrus.umllight.di.advice.interactionContents" inheritance="all" editHelperAdviceClassName="org.eclipse.papyrus.umllight.core.internal.advice.InteractionContentsAdvice">
+    <target xmi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.Interaction"/>
+  </adviceBindingsConfigurations>
 </elementtypesconfigurations:ElementTypeSetConfiguration>

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/InteractionContentsAdvice.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/InteractionContentsAdvice.java
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal.advice;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.gmf.runtime.emf.core.util.PackageUtil;
+import org.eclipse.gmf.runtime.emf.type.core.edithelper.AbstractEditHelperAdvice;
+import org.eclipse.gmf.runtime.emf.type.core.requests.CreateElementRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.IEditCommandRequest;
+import org.eclipse.uml2.uml.Class;
+import org.eclipse.uml2.uml.Interaction;
+import org.eclipse.uml2.uml.UMLPackage;
+
+/**
+ * Edit-helper advice to suppress creation of features and other contents of
+ * {@link Class}es that are not interesting in {@link Interaction}s in the
+ * <em>UML Light</em> context.
+ */
+public class InteractionContentsAdvice extends AbstractEditHelperAdvice {
+
+	/**
+	 * Initializes me.
+	 */
+	public InteractionContentsAdvice() {
+		super();
+	}
+
+	@Override
+	public boolean approveRequest(IEditCommandRequest request) {
+		if (request instanceof CreateElementRequest) {
+			return approveCreateRequest((CreateElementRequest) request);
+		}
+		return super.approveRequest(request);
+	}
+
+	/**
+	 * Query whether a {@code request} to create an element should be permitted.
+	 * 
+	 * @param request a create-element request
+	 * @return {@code false} if that {@code request} should be denied; {@code true}
+	 *         otherwise
+	 */
+	protected boolean approveCreateRequest(CreateElementRequest request) {
+		boolean result = true;
+
+		EReference containment = request.getContainmentFeature();
+		if (containment == null) {
+			// We'll be looking for the best-fit containment feature later
+			containment = PackageUtil.findFeature(request.getContainer().eClass(),
+					request.getElementType().getEClass());
+		}
+
+		if (containment != null) {
+			EClass owner = containment.getEContainingClass();
+			result = (owner == UMLPackage.Literals.INTERACTION) // Needed by the diagram editor
+					|| (owner == UMLPackage.Literals.ELEMENT); // For owned comment
+			// Exclude Behavior as owner: we don't want behavior parameters in UML Light
+		}
+
+		return result;
+	}
+}


### PR DESCRIPTION
Define an edit-helper advice to restrict the creation of elements within an `Interaction` to only the `Comment`,
excluding things that a `Class` or `Behavior` can own for which we provide **New Child** menu items that otherwise would show up because an `Interaction` is a `Behavior` (which is a `Class`).