### PR TITLE
Fix #45 Import primitive types in new models

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,10 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.infra.newchild;bundle-version="[4.0.0,5.0.0)",
  org.eclipse.papyrus.uml.diagram.wizards;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.papyrus.infra.core;bundle-version="[3.0.100,4.0.0)",
- org.eclipse.papyrus.infra.architecture;bundle-version="[2.0.0,3.0.0)"
+ org.eclipse.papyrus.infra.architecture;bundle-version="[2.0.0,3.0.0)",
+ org.eclipse.uml2.uml;bundle-version="[5.4.0,6.0.0)",
+ org.eclipse.papyrus.infra.services.semantic;bundle-version="[2.0.0,3.0.0)",
+ org.eclipse.papyrus.infra.emf;bundle-version="[3.0.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.umllight.ui.internal;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.papyrus.infra.core.log.LogHelper;
 import org.eclipse.papyrus.umllight.ui.internal.newchild.CreationMenuCleaner;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.progress.UIJob;
@@ -30,6 +31,8 @@ public class Activator extends AbstractUIPlugin {
 	// The shared instance
 	private static Activator plugin;
 
+	private LogHelper logHelper;
+
 	/**
 	 * Initializes me.
 	 */
@@ -40,6 +43,7 @@ public class Activator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 
+		logHelper = new LogHelper(context.getBundle());
 		plugin = this;
 
 		configureCreationMenus();
@@ -47,6 +51,7 @@ public class Activator extends AbstractUIPlugin {
 
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
+		logHelper = null;
 
 		super.stop(context);
 	}
@@ -70,5 +75,9 @@ public class Activator extends AbstractUIPlugin {
 				return CreationMenuCleaner.clean();
 			}
 		}.schedule();
+	}
+
+	public void log(Throwable exception) {
+		logHelper.error("Uncaught exception", exception); //$NON-NLS-1$
 	}
 }

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/wizard/InitUMLLightModelWizard.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/wizard/InitUMLLightModelWizard.java
@@ -91,6 +91,9 @@ public class InitUMLLightModelWizard extends InitModelWizard {
 			kernel.initDomainModel(modelSet, contextId, viewpointIds);
 		} else {
 			super.initDomainModel(modelSet, contextId, viewpointIds);
+
+			// Standard content for UML Light, e.g. library imports
+			kernel.initDomainModel(modelSet);
 		}
 	}
 

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/wizard/NewUMLLightProjectWizard.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/wizard/NewUMLLightProjectWizard.java
@@ -12,6 +12,7 @@
 package org.eclipse.papyrus.umllight.ui.internal.wizard;
 
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.papyrus.infra.core.resource.ModelSet;
 import org.eclipse.papyrus.uml.diagram.wizards.pages.SelectRepresentationKindPage;
 import org.eclipse.papyrus.uml.diagram.wizards.wizards.NewPapyrusProjectWizard;
 import org.eclipse.ui.IWorkbench;
@@ -64,4 +65,11 @@ public class NewUMLLightProjectWizard extends NewPapyrusProjectWizard {
 		return kernel.createSelectRepresentationKindPage();
 	}
 
+	@Override
+	protected void initDomainModel(ModelSet modelSet, String contextId, String[] viewpointIds) {
+		super.initDomainModel(modelSet, contextId, viewpointIds);
+
+		// Standard content for UML Light, e.g. library imports
+		kernel.initDomainModel(modelSet);
+	}
 }


### PR DESCRIPTION
Add an import of the _UML Primitive Types Library_ package by default in
- new models
- the model created for a new project

Note that this import is **not** added when initializing a model from an existing UML resource.
