### PR TITLE
Fix #15 Finish up diagram styles

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
@@ -39,7 +39,7 @@
       </editpolicyProvider>
    </extension>
     <extension
-         name="UML Subset for UML LIght"
+         name="UML Subset for UML Light"
          point="org.eclipse.papyrus.infra.properties.contexts">
 		<context appliedByDefault="true" contextModel="resource/context/UML-Light.contexts" isCustomizable="true"/>
 	</extension>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/architecture/UMLLight.architecture
@@ -183,7 +183,7 @@
       <assistantRules xmi:type="gmfdiagrepresentation:AssistantRule" xmi:id="_TpWdINuYEeiC9qMBYIg5kQ" permit="false" elementTypeID="*"/>
       <palettes xmi:type="paletteconfiguration:PaletteConfiguration" href="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/palette/UMLLightStateMachineDiagram.paletteconfiguration#/"/>
     </representationKinds>
-    <representationKinds xmi:type="gmfdiagrepresentation:PapyrusDiagram" xmi:id="_tSZdkNyNEeied6dzn3Rt8g" id="org.eclipse.papyrus.umllight.di.sequence" name="Light Sequence Diagram" icon="platform:/plugin/org.eclipse.papyrus.uml.diagram.sequence/icons/obj16/Diagram_Sequence.gif" concerns="__JaYANOxEeiTpIcrXWETSQ" implementationID="PapyrusUMLSequenceDiagram" creationCommandClass="org.eclipse.papyrus.uml.diagram.sequence.CreateSequenceDiagramCommand">
+    <representationKinds xmi:type="gmfdiagrepresentation:PapyrusDiagram" xmi:id="_tSZdkNyNEeied6dzn3Rt8g" id="org.eclipse.papyrus.umllight.di.sequence" name="Light Sequence Diagram" icon="platform:/plugin/org.eclipse.papyrus.uml.diagram.sequence/icons/obj16/Diagram_Sequence.gif" concerns="__JaYANOxEeiTpIcrXWETSQ" implementationID="PapyrusUMLSequenceDiagram" customStyle="platform:/plugin/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css" creationCommandClass="org.eclipse.papyrus.uml.diagram.sequence.CreateSequenceDiagramCommand">
       <modelRules xmi:type="representation:ModelRule" xmi:id="_tSZdkdyNEeied6dzn3Rt8g" permit="true" elementMultiplicity="1" multiplicity="-1">
         <element xmi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Interaction"/>
       </modelRules>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css
@@ -77,6 +77,12 @@ Property {
 	maskLabel: name type multiplicity;
 }
 
+Association  {
+	fillColor: white;
+	lineColor: steelblue;
+	shadow: false;
+}
+
 Association > Label,
 AssociationClass > Label {
 	elementIcon: false;

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/style/umllight_style.css
@@ -13,16 +13,22 @@
  */
 
 ClassDiagram *,
-UseCaseDiagram * {
+UseCaseDiagram *,
+SequenceDiagram * {
 	gradient: none;
 	transparency: 0;
 	lineWidth: 1px;
-	elementIcon: true;
 	shadow: true;
 	shadowWidth: 2px;
 	shadowColor: darkgray;
 	radiusWidth: 3px;
 	radiusHeight: 3px;
+	lineColor: steelblue;
+}
+
+ClassDiagram *,
+UseCaseDiagram * {
+	elementIcon: true;	
 }
 
 Comment {
@@ -38,19 +44,12 @@ Constraint {
 }
 
 AssociationClass, Class, DataType, Enumeration, Package, Interface, PrimitiveType,
-UseCase, StateMachine, State, Region {
+UseCase, StateMachine, State, Region, Activity, Interaction, InteractionUse {
 	fillColor: white;
 	lineColor: steelblue;
 	nameBackgroundColor: ghostwhite;
-}
-
-/* Line between member end classes should be black, we but can only style complete AssociationClass */
-AssociationClass {
-	lineColor: #000000;
-}
-
-Package {
-	fillColor: white;
+	shadow: true;
+	shadowWidth: 2px;
 }
 
 /* hide compartments by default */
@@ -78,7 +77,8 @@ Property {
 	maskLabel: name type multiplicity;
 }
 
-Association > Label {
+Association > Label,
+AssociationClass > Label {
 	elementIcon: false;
 }
 
@@ -88,12 +88,18 @@ Association > Label:targetMultiplicity {
 }
  
 Association > Label:sourceRole,
-Association > Label:targetRole {
+Association > Label:targetRole,
+AssociationClass > Label:sourceRole,
+AssociationClass > Label:targetRole {
 	maskLabel: name multiplicity;
 }
 
 Association > Label:name,
-Usage > Label {
+Usage > Label,
+ContextLink > Label,
+CommentLink > Label,
+ConstraintLink > Label,
+ActivityFinalNode > Label {
 	visible: false;
 }
 
@@ -132,6 +138,42 @@ StateMachine * {
 	shadowWidth: 0px;
 }
 
-FinalState * {
-	fillColor: white;
+Transition,
+Pseudostate {
+	lineColor: steelblue;
+}
+
+Pseudostate > Label,
+FinalState > Label,
+ForkNode > Label,
+MergeNode > Label,
+DecisionNode > Label,
+JoinNode > Label,
+InitialNode > Label,
+FlowFinalNode > Label,
+InputPin > Label,
+OutputPin > Label {
+	visible: false;
+}
+
+FinalState, Pseudostate, InitialNode {
+	fillColor: steelblue;
+	lineColor: steelblue;
+}
+
+OpaqueAction, CallBehaviorAction, CallOperationAction, AcceptEventAction, InputPin, OutputPin,
+ControlFlow, FlowFinalNode, DecisionNode, MergeNode, ForkNode, JoinNode, ActivityFinalNode,
+BehaviorExecutionSpecification, ActionExecutionSpecification {
+	lineColor: steelblue;
+	fillColor: ghostwhite;
+}
+
+OpaqueAction,
+CallBehaviorAction,
+CallOperationAction {
+	elementIcon: true;
+}
+
+Lifeline, Message {
+	lineColor: steelblue;
 }


### PR DESCRIPTION
Adds diagram style for activity and sequence diagram, as well as several
improvements including the coloring of associations as discussed in #15,
and refactorings to ease maintenance. Also introduces more consistency,
e.g. element icons of association classes are now hidden. Element icons
are only shown if a similar shape is used for different types of
elements on the same diagram.