### PR TITLE
Fix #55 and #60 Class and package diagram Properties view simplification

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
@@ -43,4 +43,9 @@
          point="org.eclipse.papyrus.infra.properties.contexts">
 		<context appliedByDefault="true" contextModel="resource/context/UML-Light.contexts" isCustomizable="true"/>
 	</extension>
+   <extension 
+         name="Properties View Environment for UML Light"
+         point="org.eclipse.papyrus.infra.properties.environments">
+      <environment environmentModel="resource/context/Environment.xmi"/>
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/Environment.xmi
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/Environment.xmi
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ASCII"?>
+<environment:Environment
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:environment="http://www.eclipse.org/papyrus/properties/environment/0.9">
+  <propertyEditorTypes
+      label="Light Multiplicity Editor"
+      widgetClass="UMLLightMultiplicityDialog"
+      namespace="//@namespaces.0"
+      type="Reference"/>
+  <namespaces
+      name="umllight"
+      value="org.eclipse.papyrus.umllight.ui.properties.widgets"/>
+</environment:Environment>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
@@ -260,6 +260,11 @@
       <widget href="ui/SingleTypedElement.xwt#/"/>
     </sections>
   </tabs>
+  <tabs xmi:id="_vMwxgP8IEeif09Qs_5sVbA" label="Constraints" id="uml-light-constraints" category="org.eclipse.papyrus" image="" priority="11">
+    <sections xmi:id="_vMwxgf8IEeif09Qs_5sVbA" name="SingleOperationConstraints" sectionFile="ui/SingleOperationConstraints.xwt">
+      <widget href="ui/SingleOperationConstraints.xwt#/"/>
+    </sections>
+  </tabs>
   <views xmi:id="_69ur3KDJEeSZxfCXzZz3-w" name="SingleFinalState" sections="_69cXZ6DJEeSZxfCXzZz3-w" automaticContext="true">
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_69ur3aDJEeSZxfCXzZz3-w" name="isSingleFinalState">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
@@ -723,7 +728,7 @@
       <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMSf7xEeioQ5IXbg1K0w" name="umlClassName" value="OpaqueExpression"/>
     </constraints>
   </views>
-  <views xmi:id="_3OPMSv7xEeioQ5IXbg1K0w" name="SingleOperation" sections="_3OOlPv7xEeioQ5IXbg1K0w" automaticContext="true">
+  <views xmi:id="_3OPMSv7xEeioQ5IXbg1K0w" name="SingleOperation" sections="_3OOlPv7xEeioQ5IXbg1K0w _vMwxgf8IEeif09Qs_5sVbA" automaticContext="true">
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMS_7xEeioQ5IXbg1K0w" name="isSingleOperation">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
       <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMTP7xEeioQ5IXbg1K0w" name="umlClassName" value="Operation"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
@@ -40,6 +40,225 @@
     <sections xmi:id="_69idmaDJEeSZxfCXzZz3-w" name="SingleComment" sectionFile="ui/SingleComment.xwt">
       <widget href="ui/SingleComment.xwt#/"/>
     </sections>
+    <sections xmi:id="_3OOlAP7xEeioQ5IXbg1K0w" name="MemberEnd" sectionFile="ui/MemberEnd.xwt">
+      <widget href="ui/MemberEnd.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlAf7xEeioQ5IXbg1K0w" name="MultipleAssociation" sectionFile="ui/MultipleAssociation.xwt">
+      <widget href="ui/MultipleAssociation.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlAv7xEeioQ5IXbg1K0w" name="MultipleAssociationClass" sectionFile="ui/MultipleAssociationClass.xwt">
+      <widget href="ui/MultipleAssociationClass.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlA_7xEeioQ5IXbg1K0w" name="MultipleClass" sectionFile="ui/MultipleClass.xwt">
+      <widget href="ui/MultipleClass.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlBP7xEeioQ5IXbg1K0w" name="MultipleClassifier" sectionFile="ui/MultipleClassifier.xwt">
+      <widget href="ui/MultipleClassifier.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlBf7xEeioQ5IXbg1K0w" name="MultipleConstraint" sectionFile="ui/MultipleConstraint.xwt">
+      <widget href="ui/MultipleConstraint.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlBv7xEeioQ5IXbg1K0w" name="MultipleDataType" sectionFile="ui/MultipleDataType.xwt">
+      <widget href="ui/MultipleDataType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlB_7xEeioQ5IXbg1K0w" name="MultipleDependency" sectionFile="ui/MultipleDependency.xwt">
+      <widget href="ui/MultipleDependency.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlCP7xEeioQ5IXbg1K0w" name="MultipleElement" sectionFile="ui/MultipleElement.xwt">
+      <widget href="ui/MultipleElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlCf7xEeioQ5IXbg1K0w" name="MultipleEnumeration" sectionFile="ui/MultipleEnumeration.xwt">
+      <widget href="ui/MultipleEnumeration.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlCv7xEeioQ5IXbg1K0w" name="MultipleEnumerationLiteral" sectionFile="ui/MultipleEnumerationLiteral.xwt">
+      <widget href="ui/MultipleEnumerationLiteral.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlC_7xEeioQ5IXbg1K0w" name="MultipleExpression" sectionFile="ui/MultipleExpression.xwt">
+      <widget href="ui/MultipleExpression.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlDP7xEeioQ5IXbg1K0w" name="MultipleFeature" sectionFile="ui/MultipleFeature.xwt">
+      <widget href="ui/MultipleFeature.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlDf7xEeioQ5IXbg1K0w" name="MultipleGeneralization" sectionFile="ui/MultipleGeneralization.xwt">
+      <widget href="ui/MultipleGeneralization.xwt#/"/>
+    </sections>
+    <sections xmi:id="_z5kJwP8GEeiem9LAZuCuxA" name="MultipleInstanceValue" sectionFile="ui/MultipleInstanceValue.xwt">
+      <widget href="ui/MultipleInstanceValue.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlDv7xEeioQ5IXbg1K0w" name="MultipleInterface" sectionFile="ui/MultipleInterface.xwt">
+      <widget href="ui/MultipleInterface.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlD_7xEeioQ5IXbg1K0w" name="MultipleInterfaceRealization" sectionFile="ui/MultipleInterfaceRealization.xwt">
+      <widget href="ui/MultipleInterfaceRealization.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlEP7xEeioQ5IXbg1K0w" name="MultipleLiteralBoolean" sectionFile="ui/MultipleLiteralBoolean.xwt">
+      <widget href="ui/MultipleLiteralBoolean.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlEf7xEeioQ5IXbg1K0w" name="MultipleLiteralInteger" sectionFile="ui/MultipleLiteralInteger.xwt">
+      <widget href="ui/MultipleLiteralInteger.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlEv7xEeioQ5IXbg1K0w" name="MultipleLiteralNull" sectionFile="ui/MultipleLiteralNull.xwt">
+      <widget href="ui/MultipleLiteralNull.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlE_7xEeioQ5IXbg1K0w" name="MultipleLiteralSpecification" sectionFile="ui/MultipleLiteralSpecification.xwt">
+      <widget href="ui/MultipleLiteralSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlFP7xEeioQ5IXbg1K0w" name="MultipleLiteralString" sectionFile="ui/MultipleLiteralString.xwt">
+      <widget href="ui/MultipleLiteralString.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlFf7xEeioQ5IXbg1K0w" name="MultipleLiteralUnlimitedNatural" sectionFile="ui/MultipleLiteralUnlimitedNatural.xwt">
+      <widget href="ui/MultipleLiteralUnlimitedNatural.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlFv7xEeioQ5IXbg1K0w" name="MultipleModel" sectionFile="ui/MultipleModel.xwt">
+      <widget href="ui/MultipleModel.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlF_7xEeioQ5IXbg1K0w" name="MultipleMultiplicityElement" sectionFile="ui/MultipleMultiplicityElement.xwt">
+      <widget href="ui/MultipleMultiplicityElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlGP7xEeioQ5IXbg1K0w" name="MultipleNamedElement" sectionFile="ui/MultipleNamedElement.xwt">
+      <widget href="ui/MultipleNamedElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlGf7xEeioQ5IXbg1K0w" name="MultipleNamespace" sectionFile="ui/MultipleNamespace.xwt">
+      <widget href="ui/MultipleNamespace.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlGv7xEeioQ5IXbg1K0w" name="MultipleOpaqueExpression" sectionFile="ui/MultipleOpaqueExpression.xwt">
+      <widget href="ui/MultipleOpaqueExpression.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlG_7xEeioQ5IXbg1K0w" name="MultipleOperation" sectionFile="ui/MultipleOperation.xwt">
+      <widget href="ui/MultipleOperation.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlHP7xEeioQ5IXbg1K0w" name="MultiplePackage" sectionFile="ui/MultiplePackage.xwt">
+      <widget href="ui/MultiplePackage.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlHf7xEeioQ5IXbg1K0w" name="MultiplePackageableElement" sectionFile="ui/MultiplePackageableElement.xwt">
+      <widget href="ui/MultiplePackageableElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlHv7xEeioQ5IXbg1K0w" name="MultipleParameter" sectionFile="ui/MultipleParameter.xwt">
+      <widget href="ui/MultipleParameter.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlH_7xEeioQ5IXbg1K0w" name="MultiplePrimitiveType" sectionFile="ui/MultiplePrimitiveType.xwt">
+      <widget href="ui/MultiplePrimitiveType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlIP7xEeioQ5IXbg1K0w" name="MultipleProperty" sectionFile="ui/MultipleProperty.xwt">
+      <widget href="ui/MultipleProperty.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlIf7xEeioQ5IXbg1K0w" name="MultipleLiteralReal" sectionFile="ui/MultipleLiteralReal.xwt">
+      <widget href="ui/MultipleLiteralReal.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlIv7xEeioQ5IXbg1K0w" name="MultipleType" sectionFile="ui/MultipleType.xwt">
+      <widget href="ui/MultipleType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlI_7xEeioQ5IXbg1K0w" name="MultipleTypedElement" sectionFile="ui/MultipleTypedElement.xwt">
+      <widget href="ui/MultipleTypedElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlJP7xEeioQ5IXbg1K0w" name="SingleAssociation" sectionFile="ui/SingleAssociation.xwt">
+      <widget href="ui/SingleAssociation.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlJf7xEeioQ5IXbg1K0w" name="SingleAssociationClass" sectionFile="ui/SingleAssociationClass.xwt">
+      <widget href="ui/SingleAssociationClass.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlJv7xEeioQ5IXbg1K0w" name="SingleClass" sectionFile="ui/SingleClass.xwt">
+      <widget href="ui/SingleClass.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlJ_7xEeioQ5IXbg1K0w" name="SingleClassifier" sectionFile="ui/SingleClassifier.xwt">
+      <widget href="ui/SingleClassifier.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlKP7xEeioQ5IXbg1K0w" name="SingleConstraint" sectionFile="ui/SingleConstraint.xwt">
+      <widget href="ui/SingleConstraint.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlKf7xEeioQ5IXbg1K0w" name="SingleDataType" sectionFile="ui/SingleDataType.xwt">
+      <widget href="ui/SingleDataType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlKv7xEeioQ5IXbg1K0w" name="SingleDependency" sectionFile="ui/SingleDependency.xwt">
+      <widget href="ui/SingleDependency.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlK_7xEeioQ5IXbg1K0w" name="SingleElement" sectionFile="ui/SingleElement.xwt">
+      <widget href="ui/SingleElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlLP7xEeioQ5IXbg1K0w" name="SingleEnumeration" sectionFile="ui/SingleEnumeration.xwt">
+      <widget href="ui/SingleEnumeration.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlLf7xEeioQ5IXbg1K0w" name="SingleEnumerationLiteral" sectionFile="ui/SingleEnumerationLiteral.xwt">
+      <widget href="ui/SingleEnumerationLiteral.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlLv7xEeioQ5IXbg1K0w" name="SingleExpression" sectionFile="ui/SingleExpression.xwt">
+      <widget href="ui/SingleExpression.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlL_7xEeioQ5IXbg1K0w" name="SingleFeature" sectionFile="ui/SingleFeature.xwt">
+      <widget href="ui/SingleFeature.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlMP7xEeioQ5IXbg1K0w" name="SingleGeneralization" sectionFile="ui/SingleGeneralization.xwt">
+      <widget href="ui/SingleGeneralization.xwt#/"/>
+    </sections>
+    <sections xmi:id="_z5kJwf8GEeiem9LAZuCuxA" name="SingleInstanceValue" sectionFile="ui/SingleInstanceValue.xwt">
+      <widget href="ui/SingleInstanceValue.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlMf7xEeioQ5IXbg1K0w" name="SingleInterface" sectionFile="ui/SingleInterface.xwt">
+      <widget href="ui/SingleInterface.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlMv7xEeioQ5IXbg1K0w" name="SingleInterfaceRealization" sectionFile="ui/SingleInterfaceRealization.xwt">
+      <widget href="ui/SingleInterfaceRealization.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlM_7xEeioQ5IXbg1K0w" name="SingleLiteralBoolean" sectionFile="ui/SingleLiteralBoolean.xwt">
+      <widget href="ui/SingleLiteralBoolean.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlNP7xEeioQ5IXbg1K0w" name="SingleLiteralInteger" sectionFile="ui/SingleLiteralInteger.xwt">
+      <widget href="ui/SingleLiteralInteger.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlNf7xEeioQ5IXbg1K0w" name="SingleLiteralNull" sectionFile="ui/SingleLiteralNull.xwt">
+      <widget href="ui/SingleLiteralNull.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlNv7xEeioQ5IXbg1K0w" name="SingleLiteralSpecification" sectionFile="ui/SingleLiteralSpecification.xwt">
+      <widget href="ui/SingleLiteralSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlN_7xEeioQ5IXbg1K0w" name="SingleLiteralString" sectionFile="ui/SingleLiteralString.xwt">
+      <widget href="ui/SingleLiteralString.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlOP7xEeioQ5IXbg1K0w" name="SingleLiteralUnlimitedNatural" sectionFile="ui/SingleLiteralUnlimitedNatural.xwt">
+      <widget href="ui/SingleLiteralUnlimitedNatural.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlOf7xEeioQ5IXbg1K0w" name="SingleModel" sectionFile="ui/SingleModel.xwt">
+      <widget href="ui/SingleModel.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlOv7xEeioQ5IXbg1K0w" name="SingleMultiplicityElement" sectionFile="ui/SingleMultiplicityElement.xwt">
+      <widget href="ui/SingleMultiplicityElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlO_7xEeioQ5IXbg1K0w" name="SingleNamedElement" sectionFile="ui/SingleNamedElement.xwt">
+      <widget href="ui/SingleNamedElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlPP7xEeioQ5IXbg1K0w" name="SingleNamespace" sectionFile="ui/SingleNamespace.xwt">
+      <widget href="ui/SingleNamespace.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlPf7xEeioQ5IXbg1K0w" name="SingleOpaqueExpression" sectionFile="ui/SingleOpaqueExpression.xwt">
+      <widget href="ui/SingleOpaqueExpression.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlPv7xEeioQ5IXbg1K0w" name="SingleOperation" sectionFile="ui/SingleOperation.xwt">
+      <widget href="ui/SingleOperation.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlP_7xEeioQ5IXbg1K0w" name="SinglePackage" sectionFile="ui/SinglePackage.xwt">
+      <widget href="ui/SinglePackage.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlQP7xEeioQ5IXbg1K0w" name="SinglePackageableElement" sectionFile="ui/SinglePackageableElement.xwt">
+      <widget href="ui/SinglePackageableElement.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlQf7xEeioQ5IXbg1K0w" name="SingleParameter" sectionFile="ui/SingleParameter.xwt">
+      <widget href="ui/SingleParameter.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlQv7xEeioQ5IXbg1K0w" name="SinglePrimitiveType" sectionFile="ui/SinglePrimitiveType.xwt">
+      <widget href="ui/SinglePrimitiveType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlQ_7xEeioQ5IXbg1K0w" name="SingleProperty" sectionFile="ui/SingleProperty.xwt">
+      <widget href="ui/SingleProperty.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlRP7xEeioQ5IXbg1K0w" name="SingleLiteralReal" sectionFile="ui/SingleLiteralReal.xwt">
+      <widget href="ui/SingleLiteralReal.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlRf7xEeioQ5IXbg1K0w" name="SingleType" sectionFile="ui/SingleType.xwt">
+      <widget href="ui/SingleType.xwt#/"/>
+    </sections>
+    <sections xmi:id="_3OOlRv7xEeioQ5IXbg1K0w" name="SingleTypedElement" sectionFile="ui/SingleTypedElement.xwt">
+      <widget href="ui/SingleTypedElement.xwt#/"/>
+    </sections>
   </tabs>
   <views xmi:id="_69ur3KDJEeSZxfCXzZz3-w" name="SingleFinalState" sections="_69cXZ6DJEeSZxfCXzZz3-w" automaticContext="true">
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_69ur3aDJEeSZxfCXzZz3-w" name="isSingleFinalState">
@@ -117,6 +336,439 @@
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_69usrKDJEeSZxfCXzZz3-w" name="isSingleComment">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
       <properties xsi:type="constraints:ValueProperty" xmi:id="_69usraDJEeSZxfCXzZz3-w" name="umlClassName" value="Comment"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlR_7xEeioQ5IXbg1K0w" name="MemberEnd" sections="_3OOlAP7xEeioQ5IXbg1K0w"/>
+  <views xmi:id="_3OOlSP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleAssociation" sections="_3OOlAf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlSf7xEeioQ5IXbg1K0w" name="isMultipleAssociation">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlSv7xEeioQ5IXbg1K0w" name="umlClassName" value="Association"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlS_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleAssociationClass" sections="_3OOlAv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlTP7xEeioQ5IXbg1K0w" name="isMultipleAssociationClass">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlTf7xEeioQ5IXbg1K0w" name="umlClassName" value="AssociationClass"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlTv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleClass" sections="_3OOlA_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlT_7xEeioQ5IXbg1K0w" name="isMultipleClass">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlUP7xEeioQ5IXbg1K0w" name="umlClassName" value="Class"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlUf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleClassifier" sections="_3OOlBP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlUv7xEeioQ5IXbg1K0w" name="isMultipleClassifier">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlU_7xEeioQ5IXbg1K0w" name="umlClassName" value="Classifier"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlVP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleConstraint" sections="_3OOlBf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlVf7xEeioQ5IXbg1K0w" name="isMultipleConstraint">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlVv7xEeioQ5IXbg1K0w" name="umlClassName" value="Constraint"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlV_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleDataType" sections="_3OOlBv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlWP7xEeioQ5IXbg1K0w" name="isMultipleDataType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlWf7xEeioQ5IXbg1K0w" name="umlClassName" value="DataType"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlWv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleDependency" sections="_3OOlB_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlW_7xEeioQ5IXbg1K0w" name="isMultipleDependency">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlXP7xEeioQ5IXbg1K0w" name="umlClassName" value="Dependency"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlXf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleElement" sections="_3OOlCP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlXv7xEeioQ5IXbg1K0w" name="isMultipleElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlX_7xEeioQ5IXbg1K0w" name="umlClassName" value="Element"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlYP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleEnumeration" sections="_3OOlCf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlYf7xEeioQ5IXbg1K0w" name="isMultipleEnumeration">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlYv7xEeioQ5IXbg1K0w" name="umlClassName" value="Enumeration"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlY_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleEnumerationLiteral" sections="_3OOlCv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlZP7xEeioQ5IXbg1K0w" name="isMultipleEnumerationLiteral">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlZf7xEeioQ5IXbg1K0w" name="umlClassName" value="EnumerationLiteral"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlZv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleExpression" sections="_3OOlC_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlZ_7xEeioQ5IXbg1K0w" name="isMultipleExpression">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlaP7xEeioQ5IXbg1K0w" name="umlClassName" value="Expression"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlaf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleFeature" sections="_3OOlDP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlav7xEeioQ5IXbg1K0w" name="isMultipleFeature">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOla_7xEeioQ5IXbg1K0w" name="umlClassName" value="Feature"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlbP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleGeneralization" sections="_3OOlDf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlbf7xEeioQ5IXbg1K0w" name="isMultipleGeneralization">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlbv7xEeioQ5IXbg1K0w" name="umlClassName" value="Generalization"/>
+    </constraints>
+  </views>
+  <views xmi:id="_z5kJwv8GEeiem9LAZuCuxA" elementMultiplicity="-1" name="MultipleInstanceValue" sections="_z5kJwP8GEeiem9LAZuCuxA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_z5kJw_8GEeiem9LAZuCuxA" name="isMultipleInstanceValue">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_z5kJxP8GEeiem9LAZuCuxA" name="umlClassName" value="InstanceValue"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlb_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleInterface" sections="_3OOlDv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlcP7xEeioQ5IXbg1K0w" name="isMultipleInterface">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlcf7xEeioQ5IXbg1K0w" name="umlClassName" value="Interface"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlcv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleInterfaceRealization" sections="_3OOlD_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlc_7xEeioQ5IXbg1K0w" name="isMultipleInterfaceRealization">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOldP7xEeioQ5IXbg1K0w" name="umlClassName" value="InterfaceRealization"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOldf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralBoolean" sections="_3OOlEP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOldv7xEeioQ5IXbg1K0w" name="isMultipleLiteralBoolean">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOld_7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralBoolean"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOleP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralInteger" sections="_3OOlEf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlef7xEeioQ5IXbg1K0w" name="isMultipleLiteralInteger">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlev7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralInteger"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOle_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralNull" sections="_3OOlEv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlfP7xEeioQ5IXbg1K0w" name="isMultipleLiteralNull">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlff7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralNull"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlqP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralReal" sections="_3OOlIf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlqf7xEeioQ5IXbg1K0w" name="isMultipleLiteralReal">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlqv7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralReal"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlfv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralSpecification" sections="_3OOlE_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlf_7xEeioQ5IXbg1K0w" name="isMultipleLiteralSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlgP7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlgf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralString" sections="_3OOlFP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlgv7xEeioQ5IXbg1K0w" name="isMultipleLiteralString">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlg_7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralString"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlhP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleLiteralUnlimitedNatural" sections="_3OOlFf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlhf7xEeioQ5IXbg1K0w" name="isMultipleLiteralUnlimitedNatural">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlhv7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralUnlimitedNatural"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlh_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleModel" sections="_3OOlFv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOliP7xEeioQ5IXbg1K0w" name="isMultipleModel">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlif7xEeioQ5IXbg1K0w" name="umlClassName" value="Model"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOliv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleMultiplicityElement" sections="_3OOlF_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOli_7xEeioQ5IXbg1K0w" name="isMultipleMultiplicityElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOljP7xEeioQ5IXbg1K0w" name="umlClassName" value="MultiplicityElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOljf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleNamedElement" sections="_3OOlGP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOljv7xEeioQ5IXbg1K0w" name="isMultipleNamedElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlj_7xEeioQ5IXbg1K0w" name="umlClassName" value="NamedElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlkP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleNamespace" sections="_3OOlGf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlkf7xEeioQ5IXbg1K0w" name="isMultipleNamespace">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlkv7xEeioQ5IXbg1K0w" name="umlClassName" value="Namespace"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlk_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleOpaqueExpression" sections="_3OOlGv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOllP7xEeioQ5IXbg1K0w" name="isMultipleOpaqueExpression">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOllf7xEeioQ5IXbg1K0w" name="umlClassName" value="OpaqueExpression"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOllv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleOperation" sections="_3OOlG_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOll_7xEeioQ5IXbg1K0w" name="isMultipleOperation">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlmP7xEeioQ5IXbg1K0w" name="umlClassName" value="Operation"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlmf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultiplePackage" sections="_3OOlHP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlmv7xEeioQ5IXbg1K0w" name="isMultiplePackage">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlm_7xEeioQ5IXbg1K0w" name="umlClassName" value="Package"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlnP7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultiplePackageableElement" sections="_3OOlHf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlnf7xEeioQ5IXbg1K0w" name="isMultiplePackageableElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlnv7xEeioQ5IXbg1K0w" name="umlClassName" value="PackageableElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOln_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleParameter" sections="_3OOlHv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOloP7xEeioQ5IXbg1K0w" name="isMultipleParameter">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlof7xEeioQ5IXbg1K0w" name="umlClassName" value="Parameter"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlov7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultiplePrimitiveType" sections="_3OOlH_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlo_7xEeioQ5IXbg1K0w" name="isMultiplePrimitiveType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlpP7xEeioQ5IXbg1K0w" name="umlClassName" value="PrimitiveType"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlpf7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleProperty" sections="_3OOlIP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlpv7xEeioQ5IXbg1K0w" name="isMultipleProperty">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlp_7xEeioQ5IXbg1K0w" name="umlClassName" value="Property"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlq_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleType" sections="_3OOlIv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlrP7xEeioQ5IXbg1K0w" name="isMultipleType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlrf7xEeioQ5IXbg1K0w" name="umlClassName" value="Type"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlrv7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleTypedElement" sections="_3OOlI_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlr_7xEeioQ5IXbg1K0w" name="isMultipleTypedElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlsP7xEeioQ5IXbg1K0w" name="umlClassName" value="TypedElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlsf7xEeioQ5IXbg1K0w" name="SingleAssociation" sections="_3OOlJP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlsv7xEeioQ5IXbg1K0w" name="isSingleAssociation">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOls_7xEeioQ5IXbg1K0w" name="umlClassName" value="Association"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOltP7xEeioQ5IXbg1K0w" name="SingleAssociationClass" sections="_3OOlJf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOltf7xEeioQ5IXbg1K0w" name="isSingleAssociationClass">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOltv7xEeioQ5IXbg1K0w" name="umlClassName" value="AssociationClass"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlt_7xEeioQ5IXbg1K0w" name="SingleClass" sections="_3OOlJv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOluP7xEeioQ5IXbg1K0w" name="isSingleClass">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOluf7xEeioQ5IXbg1K0w" name="umlClassName" value="Class"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOluv7xEeioQ5IXbg1K0w" name="SingleClassifier" sections="_3OOlJ_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlu_7xEeioQ5IXbg1K0w" name="isSingleClassifier">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlvP7xEeioQ5IXbg1K0w" name="umlClassName" value="Classifier"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlvf7xEeioQ5IXbg1K0w" name="SingleConstraint" sections="_3OOlKP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlvv7xEeioQ5IXbg1K0w" name="isSingleConstraint">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlv_7xEeioQ5IXbg1K0w" name="umlClassName" value="Constraint"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlwP7xEeioQ5IXbg1K0w" name="SingleDataType" sections="_3OOlKf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlwf7xEeioQ5IXbg1K0w" name="isSingleDataType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlwv7xEeioQ5IXbg1K0w" name="umlClassName" value="DataType"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OOlw_7xEeioQ5IXbg1K0w" name="SingleDependency" sections="_3OOlKv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOlxP7xEeioQ5IXbg1K0w" name="isSingleDependency">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMEP7xEeioQ5IXbg1K0w" name="umlClassName" value="Dependency"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMEf7xEeioQ5IXbg1K0w" name="SingleElement" sections="_3OOlK_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMEv7xEeioQ5IXbg1K0w" name="isSingleElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPME_7xEeioQ5IXbg1K0w" name="umlClassName" value="Element"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMFP7xEeioQ5IXbg1K0w" name="SingleEnumeration" sections="_3OOlLP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMFf7xEeioQ5IXbg1K0w" name="isSingleEnumeration">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMFv7xEeioQ5IXbg1K0w" name="umlClassName" value="Enumeration"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMF_7xEeioQ5IXbg1K0w" name="SingleEnumerationLiteral" sections="_3OOlLf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMGP7xEeioQ5IXbg1K0w" name="isSingleEnumerationLiteral">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMGf7xEeioQ5IXbg1K0w" name="umlClassName" value="EnumerationLiteral"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMGv7xEeioQ5IXbg1K0w" name="SingleExpression" sections="_3OOlLv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMG_7xEeioQ5IXbg1K0w" name="isSingleExpression">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMHP7xEeioQ5IXbg1K0w" name="umlClassName" value="Expression"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMHf7xEeioQ5IXbg1K0w" name="SingleFeature" sections="_3OOlL_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMHv7xEeioQ5IXbg1K0w" name="isSingleFeature">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMH_7xEeioQ5IXbg1K0w" name="umlClassName" value="Feature"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMIP7xEeioQ5IXbg1K0w" name="SingleGeneralization" sections="_3OOlMP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMIf7xEeioQ5IXbg1K0w" name="isSingleGeneralization">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMIv7xEeioQ5IXbg1K0w" name="umlClassName" value="Generalization"/>
+    </constraints>
+  </views>
+  <views xmi:id="_z5kJxf8GEeiem9LAZuCuxA" name="SingleInstanceValue" sections="_z5kJwf8GEeiem9LAZuCuxA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_z5kJxv8GEeiem9LAZuCuxA" name="isSingleInstanceValue">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_z5kJx_8GEeiem9LAZuCuxA" name="umlClassName" value="InstanceValue"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMI_7xEeioQ5IXbg1K0w" name="SingleInterface" sections="_3OOlMf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMJP7xEeioQ5IXbg1K0w" name="isSingleInterface">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMJf7xEeioQ5IXbg1K0w" name="umlClassName" value="Interface"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMJv7xEeioQ5IXbg1K0w" name="SingleInterfaceRealization" sections="_3OOlMv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMJ_7xEeioQ5IXbg1K0w" name="isSingleInterfaceRealization">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMKP7xEeioQ5IXbg1K0w" name="umlClassName" value="InterfaceRealization"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMKf7xEeioQ5IXbg1K0w" name="SingleLiteralBoolean" sections="_3OOlM_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMKv7xEeioQ5IXbg1K0w" name="isSingleLiteralBoolean">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMK_7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralBoolean"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMLP7xEeioQ5IXbg1K0w" name="SingleLiteralInteger" sections="_3OOlNP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMLf7xEeioQ5IXbg1K0w" name="isSingleLiteralInteger">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMLv7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralInteger"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPML_7xEeioQ5IXbg1K0w" name="SingleLiteralNull" sections="_3OOlNf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMMP7xEeioQ5IXbg1K0w" name="isSingleLiteralNull">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMMf7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralNull"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMXP7xEeioQ5IXbg1K0w" name="SingleLiteralReal" sections="_3OOlRP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMXf7xEeioQ5IXbg1K0w" name="isSingleLiteralReal">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMXv7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralReal"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMMv7xEeioQ5IXbg1K0w" name="SingleLiteralSpecification" sections="_3OOlNv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMM_7xEeioQ5IXbg1K0w" name="isSingleLiteralSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMNP7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMNf7xEeioQ5IXbg1K0w" name="SingleLiteralString" sections="_3OOlN_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMNv7xEeioQ5IXbg1K0w" name="isSingleLiteralString">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMN_7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralString"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMOP7xEeioQ5IXbg1K0w" name="SingleLiteralUnlimitedNatural" sections="_3OOlOP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMOf7xEeioQ5IXbg1K0w" name="isSingleLiteralUnlimitedNatural">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMOv7xEeioQ5IXbg1K0w" name="umlClassName" value="LiteralUnlimitedNatural"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMO_7xEeioQ5IXbg1K0w" name="SingleModel" sections="_3OOlOf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMPP7xEeioQ5IXbg1K0w" name="isSingleModel">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMPf7xEeioQ5IXbg1K0w" name="umlClassName" value="Model"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMPv7xEeioQ5IXbg1K0w" name="SingleMultiplicityElement" sections="_3OOlOv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMP_7xEeioQ5IXbg1K0w" name="isSingleMultiplicityElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMQP7xEeioQ5IXbg1K0w" name="umlClassName" value="MultiplicityElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMQf7xEeioQ5IXbg1K0w" name="SingleNamedElement" sections="_3OOlO_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMQv7xEeioQ5IXbg1K0w" name="isSingleNamedElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMQ_7xEeioQ5IXbg1K0w" name="umlClassName" value="NamedElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMRP7xEeioQ5IXbg1K0w" name="SingleNamespace" sections="_3OOlPP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMRf7xEeioQ5IXbg1K0w" name="isSingleNamespace">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMRv7xEeioQ5IXbg1K0w" name="umlClassName" value="Namespace"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMR_7xEeioQ5IXbg1K0w" name="SingleOpaqueExpression" sections="_3OOlPf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMSP7xEeioQ5IXbg1K0w" name="isSingleOpaqueExpression">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMSf7xEeioQ5IXbg1K0w" name="umlClassName" value="OpaqueExpression"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMSv7xEeioQ5IXbg1K0w" name="SingleOperation" sections="_3OOlPv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMS_7xEeioQ5IXbg1K0w" name="isSingleOperation">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMTP7xEeioQ5IXbg1K0w" name="umlClassName" value="Operation"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMTf7xEeioQ5IXbg1K0w" name="SinglePackage" sections="_3OOlP_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMTv7xEeioQ5IXbg1K0w" name="isSinglePackage">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMT_7xEeioQ5IXbg1K0w" name="umlClassName" value="Package"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMUP7xEeioQ5IXbg1K0w" name="SinglePackageableElement" sections="_3OOlQP7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMUf7xEeioQ5IXbg1K0w" name="isSinglePackageableElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMUv7xEeioQ5IXbg1K0w" name="umlClassName" value="PackageableElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMU_7xEeioQ5IXbg1K0w" name="SingleParameter" sections="_3OOlQf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMVP7xEeioQ5IXbg1K0w" name="isSingleParameter">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMVf7xEeioQ5IXbg1K0w" name="umlClassName" value="Parameter"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMVv7xEeioQ5IXbg1K0w" name="SinglePrimitiveType" sections="_3OOlQv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMV_7xEeioQ5IXbg1K0w" name="isSinglePrimitiveType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMWP7xEeioQ5IXbg1K0w" name="umlClassName" value="PrimitiveType"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMWf7xEeioQ5IXbg1K0w" name="SingleProperty" sections="_3OOlQ_7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMWv7xEeioQ5IXbg1K0w" name="isSingleProperty">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMW_7xEeioQ5IXbg1K0w" name="umlClassName" value="Property"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMX_7xEeioQ5IXbg1K0w" name="SingleType" sections="_3OOlRf7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMYP7xEeioQ5IXbg1K0w" name="isSingleType">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMYf7xEeioQ5IXbg1K0w" name="umlClassName" value="Type"/>
+    </constraints>
+  </views>
+  <views xmi:id="_3OPMYv7xEeioQ5IXbg1K0w" name="SingleTypedElement" sections="_3OOlRv7xEeioQ5IXbg1K0w" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMY_7xEeioQ5IXbg1K0w" name="isSingleTypedElement">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMZP7xEeioQ5IXbg1K0w" name="umlClassName" value="TypedElement"/>
     </constraints>
   </views>
   <dataContexts xmi:id="_690xgaDJEeSZxfCXzZz3-w" name="UML" label="UML">

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
@@ -133,6 +133,9 @@
     <sections xmi:id="_3OOlHf7xEeioQ5IXbg1K0w" name="MultiplePackageableElement" sectionFile="ui/MultiplePackageableElement.xwt">
       <widget href="ui/MultiplePackageableElement.xwt#/"/>
     </sections>
+    <sections xmi:id="_YN2T0P8KEeia9orao6j1zA" name="MultiplePackageImport" sectionFile="ui/MultiplePackageImport.xwt">
+      <widget href="ui/MultiplePackageImport.xwt#/"/>
+    </sections>
     <sections xmi:id="_3OOlHv7xEeioQ5IXbg1K0w" name="MultipleParameter" sectionFile="ui/MultipleParameter.xwt">
       <widget href="ui/MultipleParameter.xwt#/"/>
     </sections>
@@ -237,6 +240,9 @@
     </sections>
     <sections xmi:id="_3OOlP_7xEeioQ5IXbg1K0w" name="SinglePackage" sectionFile="ui/SinglePackage.xwt">
       <widget href="ui/SinglePackage.xwt#/"/>
+    </sections>
+    <sections xmi:id="_YN2T0f8KEeia9orao6j1zA" name="SinglePackageImport" sectionFile="ui/SinglePackageImport.xwt">
+      <widget href="ui/SinglePackageImport.xwt#/"/>
     </sections>
     <sections xmi:id="_3OOlQP7xEeioQ5IXbg1K0w" name="SinglePackageableElement" sectionFile="ui/SinglePackageableElement.xwt">
       <widget href="ui/SinglePackageableElement.xwt#/"/>
@@ -530,6 +536,12 @@
       <properties xsi:type="constraints:ValueProperty" xmi:id="_3OOlnv7xEeioQ5IXbg1K0w" name="umlClassName" value="PackageableElement"/>
     </constraints>
   </views>
+  <views xmi:id="_YN2T0v8KEeia9orao6j1zA" elementMultiplicity="-1" name="MultiplePackageImport" sections="_YN2T0P8KEeia9orao6j1zA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_YN2T0_8KEeia9orao6j1zA" name="isMultiplePackageImport">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_YN2T1P8KEeia9orao6j1zA" name="umlClassName" value="PackageImport"/>
+    </constraints>
+  </views>
   <views xmi:id="_3OOln_7xEeioQ5IXbg1K0w" elementMultiplicity="-1" name="MultipleParameter" sections="_3OOlHv7xEeioQ5IXbg1K0w" automaticContext="true">
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OOloP7xEeioQ5IXbg1K0w" name="isMultipleParameter">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
@@ -744,6 +756,12 @@
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMUf7xEeioQ5IXbg1K0w" name="isSinglePackageableElement">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
       <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMUv7xEeioQ5IXbg1K0w" name="umlClassName" value="PackageableElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_YN2T1f8KEeia9orao6j1zA" name="SinglePackageImport" sections="_YN2T0f8KEeia9orao6j1zA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_YN2T1v8KEeia9orao6j1zA" name="isSinglePackageImport">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_YN2T1_8KEeia9orao6j1zA" name="umlClassName" value="PackageImport"/>
     </constraints>
   </views>
   <views xmi:id="_3OPMU_7xEeioQ5IXbg1K0w" name="SingleParameter" sections="_3OOlQf7xEeioQ5IXbg1K0w" automaticContext="true">

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MemberEnd.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MemberEnd.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Group xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" text="Member End">
+	<Group.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Group.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}"
+			property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}"
+			property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:TypedElement:type"></ppe:ReferenceDialog>
+		<ppe:EnumCombo input="{Binding}"
+			property="MemberEnd:owner"></ppe:EnumCombo>
+		<ppe:BooleanRadio input="{Binding}"
+			property="MemberEnd:navigable"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}"
+			property="UML:Property:aggregation"></ppe:EnumCombo>
+		<uml:MultiplicityDialog input="{Binding}"
+			property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+	</Composite>
+</Group>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MemberEnd.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MemberEnd.xwt
@@ -3,7 +3,7 @@
 	xmlns:j="clr-namespace:java.lang"
 	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
 	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
-	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:umllight="clr-namespace:org.eclipse.papyrus.umllight.ui.properties.widgets"
 	xmlns:x="http://www.eclipse.org/xwt" text="Member End">
 	<Group.layout>
 		<ppel:PropertiesLayout></ppel:PropertiesLayout>
@@ -24,7 +24,7 @@
 			property="MemberEnd:navigable"></ppe:BooleanRadio>
 		<ppe:EnumCombo input="{Binding}"
 			property="UML:Property:aggregation"></ppe:EnumCombo>
-		<uml:MultiplicityDialog input="{Binding}"
-			property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<umllight:UMLLightMultiplicityDialog input="{Binding}"
+		    property="Multiplicity:multiplicity"></umllight:UMLLightMultiplicityDialog>
 	</Composite>
 </Group>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleAssociation.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleAssociation.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Association:isDerived"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleAssociationClass.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleAssociationClass.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Association:isDerived"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleClass.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleClass.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleClassifier.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleClassifier.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleConstraint.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleConstraint.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDataType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDataType.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDependency.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDependency.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleElement.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleEnumeration.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleEnumeration.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleEnumerationLiteral.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleEnumerationLiteral.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExpression.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExpression.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleFeature.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleFeature.xwt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleGeneralization.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleGeneralization.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Generalization:general"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInstanceValue.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInstanceValue.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:InstanceValue:instance"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInterface.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInterface.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInterfaceRealization.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInterfaceRealization.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:InterfaceRealization:contract"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralBoolean.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralBoolean.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:LiteralBoolean:value"></ppe:BooleanRadio>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralInteger.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralInteger.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:IntegerEditor input="{Binding}" property="UML:LiteralInteger:value"></ppe:IntegerEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralNull.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralNull.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralReal.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralReal.xwt
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+	<ppe:FloatEditor input="{Binding}" property="UML:LiteralReal:value"></ppe:FloatEditor>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralSpecification.xwt
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralString.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralString.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringMultiline input="{Binding}"
+			property="UML:LiteralString:value"></ppe:StringMultiline>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralUnlimitedNatural.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLiteralUnlimitedNatural.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:IntegerEditor input="{Binding}"
+			property="UML:LiteralUnlimitedNatural:value"></ppe:IntegerEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleModel.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleModel.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMultiplicityElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMultiplicityElement.xwt
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleNamedElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleNamedElement.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleNamespace.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleNamespace.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOpaqueExpression.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOpaqueExpression.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOperation.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOperation.xwt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:BehavioralFeature:isAbstract"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackage.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackage.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackageImport.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackageImport.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:PackageImport:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackageableElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePackageableElement.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleParameter.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleParameter.xwt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
+		<ppe:EnumCombo input="{Binding}" property="UML:Parameter:direction"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePrimitiveType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultiplePrimitiveType.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleProperty.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleProperty.xwt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Property:isDerived"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:StructuralFeature:isReadOnly"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:Property:aggregation"></ppe:EnumCombo>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+		<uml:MultiplicityDialog input="{Binding}"
+			property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleType.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleTypedElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleTypedElement.xwt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+		<ppe:ReferenceDialog property="UML:TypedElement:type"
+			input="{Binding}"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleAssociation.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleAssociation.xwt
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+		<ppe:ViewEditor numColumns="2" input="{Binding}" view="UML:MemberEnd"
+			property="UML:Association:memberEnd"></ppe:ViewEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleAssociationClass.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleAssociationClass.xwt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Association:isDerived"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:StructuredClassifier:ownedAttribute"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleClass.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleClass.xwt
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:creation="clr-namespace:org.eclipse.papyrus.infra.properties.ui.creation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:umlXtext="clr-namespace:org.eclipse.papyrus.uml.properties.xtext"
+	xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:xtext="clr-namespace:org.eclipse.papyrus.infra.widgets.xtext.creation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}"
+			property="UML:NamedElement:qualifiedName"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:StructuredClassifier:ownedAttribute"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Class:ownedOperation"></ppe:MultiReference>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}" property="UML:Classifier:useCase"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleClassifier.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleClassifier.xwt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleConstraint.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleConstraint.xwt
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<Composite>
+			<Composite.layout>
+				<ppel:PropertiesLayout></ppel:PropertiesLayout>
+			</Composite.layout>
+			<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+			<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+			<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+			<ppe:ReferenceDialog input="{Binding}"
+				property="UML:Constraint:context"></ppe:ReferenceDialog>
+		</Composite>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Constraint:constrainedElement"></ppe:MultiReference>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Constraint:specification"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDataType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDataType.xwt
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:DataType:ownedAttribute"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:DataType:ownedOperation"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDependency.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDependency.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleElement.xwt
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<uml:StereotypeApplication input="{Binding}"
+		property="StereotypeApplication:stereotypeApplication">
+		<uml:StereotypeApplication.layoutData>
+			<GridData grabExcessVerticalSpace="true"
+				grabExcessHorizontalSpace="true" verticalAlignment="FILL"
+				horizontalAlignment="FILL"></GridData>
+		</uml:StereotypeApplication.layoutData>
+	</uml:StereotypeApplication>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleEnumeration.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleEnumeration.xwt
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Enumeration:ownedLiteral"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleEnumerationLiteral.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleEnumerationLiteral.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExpression.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExpression.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:Expression:symbol"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog property="UML:TypedElement:type"
+			input="{Binding}"></ppe:ReferenceDialog>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}" property="UML:Expression:operand"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleFeature.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleFeature.xwt
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleGeneralization.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleGeneralization.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Generalization:general"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInstanceValue.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInstanceValue.xwt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:ReferenceDialog property="UML:TypedElement:type"
+			input="{Binding}"></ppe:ReferenceDialog>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:InstanceValue:instance"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInterface.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInterface.xwt
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Interface:ownedAttribute"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Interface:ownedOperation"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInterfaceRealization.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInterfaceRealization.xwt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:InterfaceRealization:contract"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralBoolean.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralBoolean.xwt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:BooleanRadio input="{Binding}" property="UML:LiteralBoolean:value"></ppe:BooleanRadio>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralInteger.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralInteger.xwt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:IntegerEditor input="{Binding}" property="UML:LiteralInteger:value"></ppe:IntegerEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralNull.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralNull.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralReal.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralReal.xwt
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+	<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	<ppe:DoubleEditor input="{Binding}" property="UML:LiteralReal:value"></ppe:DoubleEditor>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralSpecification.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralString.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralString.xwt
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:StringMultiline input="{Binding}"
+			property="UML:LiteralString:value"></ppe:StringMultiline>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralUnlimitedNatural.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLiteralUnlimitedNatural.xwt
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:UnlimitedNaturalEditor input="{Binding}"
+			property="UML:LiteralInteger:value"></ppe:UnlimitedNaturalEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleModel.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleModel.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:StringEditor property="UML:Package:URI" input="{Binding}"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}"
+			property="ImportedPackage:Package:location" readOnly="true"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMultiplicityElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMultiplicityElement.xwt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<uml:MultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMultiplicityElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMultiplicityElement.xwt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
 	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
-	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:umllight="clr-namespace:org.eclipse.papyrus.umllight.ui.properties.widgets"
 	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation">
 	<Composite.layout>
 		<ppel:PropertiesLayout></ppel:PropertiesLayout>
@@ -19,6 +19,6 @@
 		<Composite.layout>
 			<ppel:PropertiesLayout></ppel:PropertiesLayout>
 		</Composite.layout>
-		<uml:MultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<umllight:UMLLightMultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></umllight:UMLLightMultiplicityDialog>
 	</Composite>
 </Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleNamedElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleNamedElement.xwt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleNamespace.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleNamespace.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOpaqueExpression.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOpaqueExpression.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<uml:ExpressionEditor input="{Binding}"
+			property="UML:OpaqueExpression:language"></uml:ExpressionEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOperation.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOperation.xwt
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:umlXtext="clr-namespace:org.eclipse.papyrus.uml.properties.xtext"
+	xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:xtext="clr-namespace:org.eclipse.papyrus.infra.widgets.xtext.creation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:BehavioralFeature:isAbstract"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Operation:bodyCondition"></ppe:ReferenceDialog>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:BehavioralFeature:ownedParameter"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:BehavioralFeature:method"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Operation:precondition"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Operation:postcondition"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOperationConstraints.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOperationConstraints.xwt
@@ -10,27 +10,18 @@
 	</Composite.layout>
 	<Composite>
 		<Composite.layout>
-			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
 		</Composite.layout>
-		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
-		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
-	</Composite>
-	<Composite>
-		<Composite.layout>
-			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
-		</Composite.layout>
-		<ppe:BooleanRadio input="{Binding}"
-			property="UML:BehavioralFeature:isAbstract"></ppe:BooleanRadio>
-		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
-		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Operation:bodyCondition"></ppe:ReferenceDialog>
 	</Composite>
 	<Composite>
 		<Composite.layout>
 			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
 		</Composite.layout>
 		<ppe:MultiReference input="{Binding}"
-			property="UML:BehavioralFeature:ownedParameter"></ppe:MultiReference>
+			property="UML:Operation:precondition"></ppe:MultiReference>
 		<ppe:MultiReference input="{Binding}"
-			property="UML:BehavioralFeature:method"></ppe:MultiReference>
+			property="UML:Operation:postcondition"></ppe:MultiReference>
 	</Composite>
 </Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackage.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackage.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:StringEditor property="UML:Package:URI" input="{Binding}"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}"
+			property="ImportedPackage:Package:location" readOnly="true"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackageImport.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackageImport.xwt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:PackageImport:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:PackageImport:importedPackage" readOnly="true"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackageableElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePackageableElement.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleParameter.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleParameter.xwt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Composite xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
-	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+<Composite xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
 	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:umllight="clr-namespace:org.eclipse.papyrus.umllight.ui.properties.widgets"
 	xmlns:x="http://www.eclipse.org/xwt">
 	<Composite.layout>
 		<ppel:PropertiesLayout></ppel:PropertiesLayout>
@@ -28,7 +28,7 @@
 		</Composite.layout>
 		<ppe:EnumCombo input="{Binding}" property="UML:Parameter:direction"></ppe:EnumCombo>
 		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
-		<uml:MultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<umllight:UMLLightMultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></umllight:UMLLightMultiplicityDialog>
 		<ppe:ReferenceDialog input="{Binding}"
 			property="UML:Parameter:defaultValue"></ppe:ReferenceDialog>
 	</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleParameter.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleParameter.xwt
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:Parameter:direction"></ppe:EnumCombo>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
+		<uml:MultiplicityDialog input="{Binding}" property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Parameter:defaultValue"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePrimitiveType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SinglePrimitiveType.xwt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleProperty.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleProperty.xwt
@@ -2,7 +2,7 @@
 <Composite xmlns="http://www.eclipse.org/xwt/presentation"
 	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
 	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
-	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:umllight="clr-namespace:org.eclipse.papyrus.umllight.ui.properties.widgets"
 	xmlns:x="http://www.eclipse.org/xwt">
 	<Composite.layout>
 		<ppel:PropertiesLayout></ppel:PropertiesLayout>
@@ -28,8 +28,8 @@
 			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
 		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
 		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
-		<uml:MultiplicityDialog input="{Binding}"
-			property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<umllight:UMLLightMultiplicityDialog input="{Binding}"
+		    property="Multiplicity:multiplicity"></umllight:UMLLightMultiplicityDialog>
 		<ppe:ReferenceDialog input="{Binding}"
 			property="UML:Property:defaultValue"></ppe:ReferenceDialog>
 		<ppe:EnumCombo input="{Binding}" property="UML:Property:aggregation"></ppe:EnumCombo>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleProperty.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleProperty.xwt
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Property:isDerived"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isOrdered"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:StructuralFeature:isReadOnly"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Feature:isStatic"></ppe:BooleanRadio>
+		<ppe:BooleanRadio input="{Binding}"
+			property="UML:MultiplicityElement:isUnique"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:TypedElement:type"></ppe:ReferenceDialog>
+		<uml:MultiplicityDialog input="{Binding}"
+			property="Multiplicity:multiplicity"></uml:MultiplicityDialog>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Property:defaultValue"></ppe:ReferenceDialog>
+		<ppe:EnumCombo input="{Binding}" property="UML:Property:aggregation"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleType.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleType.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleTypedElement.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleTypedElement.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog property="UML:TypedElement:type"
+			input="{Binding}"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -13,10 +13,14 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.infra.architecture;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.uml2.uml;bundle-version="[5.4.0,6.0.0)",
  org.eclipse.papyrus.infra.services.semantic;bundle-version="[2.0.0,3.0.0)",
- org.eclipse.papyrus.infra.emf;bundle-version="[3.0.0,4.0.0)"
+ org.eclipse.papyrus.infra.emf;bundle-version="[3.0.0,4.0.0)",
+ org.eclipse.papyrus.uml.properties;bundle-version="[3.2.0,4.0.0)",
+ org.eclipse.papyrus.infra.properties.ui;bundle-version="[3.4.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.newchild;x-internal:=true,
- org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true
+ org.eclipse.papyrus.umllight.ui.internal.widgets.editors;x-internal:=true,
+ org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true,
+ org.eclipse.papyrus.umllight.ui.properties.widgets

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/widgets/editors/UMLLightMultiplicityEditor.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/widgets/editors/UMLLightMultiplicityEditor.java
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.widgets.editors;
+
+import org.eclipse.papyrus.infra.widgets.editors.MultiplicityDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * A customization of the Papyrus editor composite for multiplicity that
+ * restricts the editor to only the combo-box presentation (omitting the switch
+ * to the advanced mode).
+ */
+public class UMLLightMultiplicityEditor extends MultiplicityDialog {
+
+	/**
+	 * Initializes me with my {@code parent} composite and my {@code style}. I
+	 * by-pass the preference store because switching editors is not supported.
+	 * 
+	 * @param parent my parent composite
+	 * @param style  my style bits (as supported by the superclass)
+	 */
+	public UMLLightMultiplicityEditor(Composite parent, int style) {
+		super(parent, style);
+	}
+
+	@Override
+	protected void createButtons() {
+		// Don't create the switcher button
+
+		// But do fix the margins
+		if (stringComboEditor.getLayout() instanceof GridLayout) {
+			GridLayout layout = (GridLayout) stringComboEditor.getLayout();
+			layout.marginHeight = 0;
+			layout.marginWidth = 0;
+		}
+	}
+
+	@Override
+	protected GridData getLabelLayoutData() {
+		// Fix the alignment of the label relative to the combo
+		GridData result = super.getLabelLayoutData();
+		result.verticalAlignment = SWT.TOP;
+		return result;
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/properties/widgets/UMLLightMultiplicityDialog.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/properties/widgets/UMLLightMultiplicityDialog.java
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.properties.widgets;
+
+import org.eclipse.papyrus.infra.widgets.editors.MultiplicityDialog;
+import org.eclipse.papyrus.umllight.ui.internal.widgets.editors.UMLLightMultiplicityEditor;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * This is the <code>UMLLightMultiplicityDialog</code> type. Enjoy.
+ *
+ */
+public class UMLLightMultiplicityDialog extends org.eclipse.papyrus.uml.properties.widgets.MultiplicityDialog {
+
+	/**
+	 * Initializes me with my {@code parent} composite and my {@code style}. I
+	 * by-pass the preference store because switching editors is not supported.
+	 * 
+	 * @param parent my parent composite
+	 * @param style  my style bits (as supported by the superclass)
+	 */
+	public UMLLightMultiplicityDialog(Composite parent, int style) {
+		super(parent, style);
+	}
+
+	@Override
+	protected MultiplicityDialog createMultiplicityDialog(Composite parent, int style) {
+		// The superclass requires that the 'editor' field be assigned here
+		editor = new UMLLightMultiplicityEditor(parent, style);
+		return editor;
+	}
+}


### PR DESCRIPTION
Because of the common content of package and class diagrams, it was necessary to more-or-less do these together.

This pull request adds

- XWT resources for all of the supported concepts in package and class diagrams
- additions to the _UML Light_ properties context model to register the XWTs
- a custom multiplicity editor that is used to simplify the multiplicity property for elements that have it
- a properties environment model to publish the custom multiplicity editor to the framework
