### PR TITLE
Fix #62 Simplified interaction properties

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/Environment.xmi
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/Environment.xmi
@@ -3,6 +3,9 @@
     xmi:version="2.0"
     xmlns:xmi="http://www.omg.org/XMI"
     xmlns:environment="http://www.eclipse.org/papyrus/properties/environment/0.9">
+  <modelElementFactories
+      name="UML Light Factory"
+      factoryClass="org.eclipse.papyrus.umllight.ui.internal.properties.UMLLightModelElementFactory"/>
   <propertyEditorTypes
       label="Light Multiplicity Editor"
       widgetClass="UMLLightMultiplicityDialog"

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
@@ -2102,7 +2102,7 @@
       <properties xmi:id="_6964nKDJEeSZxfCXzZz3-w" name="value" label="" description="The specified Real value."/>
     </elements>
     <elements xmi:id="_6964naDJEeSZxfCXzZz3-w" name="DestructionOccurrenceSpecification" supertypes="_690zy6DJEeSZxfCXzZz3-w"/>
-    <modelElementFactory href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@modelElementFactories.1"/>
+    <modelElementFactory href="Environment.xmi#//@modelElementFactories.0"/>
   </dataContexts>
   <dataContexts xmi:id="_6964nqDJEeSZxfCXzZz3-w" name="MemberEnd" label="Multiplicity">
     <properties xmi:id="_6964n6DJEeSZxfCXzZz3-w" name="owner" label="Owner" type="Enumeration"/>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/UML-Light.contexts
@@ -265,10 +265,103 @@
     <sections xmi:id="_3OOlRv7xEeioQ5IXbg1K0w" name="SingleTypedElement" sectionFile="ui/SingleTypedElement.xwt">
       <widget href="ui/SingleTypedElement.xwt#/"/>
     </sections>
+    <sections xmi:id="_QadOkAIAEembuNUueTsgQA" name="MultipleActionExecutionSpecification" sectionFile="ui/MultipleActionExecutionSpecification.xwt">
+      <widget href="ui/MultipleActionExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOkQIAEembuNUueTsgQA" name="MultipleBehavior" sectionFile="ui/MultipleBehavior.xwt">
+      <widget href="ui/MultipleBehavior.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOkgIAEembuNUueTsgQA" name="MultipleBehaviorExecutionSpecification" sectionFile="ui/MultipleBehaviorExecutionSpecification.xwt">
+      <widget href="ui/MultipleBehaviorExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOkwIAEembuNUueTsgQA" name="MultipleDestructionOccurrenceSpecification" sectionFile="ui/MultipleDestructionOccurrenceSpecification.xwt">
+      <widget href="ui/MultipleDestructionOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOlAIAEembuNUueTsgQA" name="MultipleExecutionOccurrenceSpecification" sectionFile="ui/MultipleExecutionOccurrenceSpecification.xwt">
+      <widget href="ui/MultipleExecutionOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOlQIAEembuNUueTsgQA" name="MultipleExecutionSpecification" sectionFile="ui/MultipleExecutionSpecification.xwt">
+      <widget href="ui/MultipleExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOlgIAEembuNUueTsgQA" name="MultipleInteraction" sectionFile="ui/MultipleInteraction.xwt">
+      <widget href="ui/MultipleInteraction.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOlwIAEembuNUueTsgQA" name="MultipleInteractionFragment" sectionFile="ui/MultipleInteractionFragment.xwt">
+      <widget href="ui/MultipleInteractionFragment.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOmAIAEembuNUueTsgQA" name="MultipleInteractionUse" sectionFile="ui/MultipleInteractionUse.xwt">
+      <widget href="ui/MultipleInteractionUse.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOmQIAEembuNUueTsgQA" name="MultipleLifeline" sectionFile="ui/MultipleLifeline.xwt">
+      <widget href="ui/MultipleLifeline.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOmgIAEembuNUueTsgQA" name="MultipleMessage" sectionFile="ui/MultipleMessage.xwt">
+      <widget href="ui/MultipleMessage.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOmwIAEembuNUueTsgQA" name="MultipleMessageEnd" sectionFile="ui/MultipleMessageEnd.xwt">
+      <widget href="ui/MultipleMessageEnd.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOnAIAEembuNUueTsgQA" name="MultipleMessageOccurrenceSpecification" sectionFile="ui/MultipleMessageOccurrenceSpecification.xwt">
+      <widget href="ui/MultipleMessageOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOnQIAEembuNUueTsgQA" name="MultipleOccurrenceSpecification" sectionFile="ui/MultipleOccurrenceSpecification.xwt">
+      <widget href="ui/MultipleOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOngIAEembuNUueTsgQA" name="MultipleOpaqueBehavior" sectionFile="ui/MultipleOpaqueBehavior.xwt">
+      <widget href="ui/MultipleOpaqueBehavior.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOnwIAEembuNUueTsgQA" name="SingleActionExecutionSpecification" sectionFile="ui/SingleActionExecutionSpecification.xwt">
+      <widget href="ui/SingleActionExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOoAIAEembuNUueTsgQA" name="SingleBehavior" sectionFile="ui/SingleBehavior.xwt">
+      <widget href="ui/SingleBehavior.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOoQIAEembuNUueTsgQA" name="SingleBehaviorExecutionSpecification" sectionFile="ui/SingleBehaviorExecutionSpecification.xwt">
+      <widget href="ui/SingleBehaviorExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOogIAEembuNUueTsgQA" name="SingleDestructionOccurrenceSpecification" sectionFile="ui/SingleDestructionOccurrenceSpecification.xwt">
+      <widget href="ui/SingleDestructionOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOowIAEembuNUueTsgQA" name="SingleExecutionOccurrenceSpecification" sectionFile="ui/SingleExecutionOccurrenceSpecification.xwt">
+      <widget href="ui/SingleExecutionOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOpAIAEembuNUueTsgQA" name="SingleExecutionSpecification" sectionFile="ui/SingleExecutionSpecification.xwt">
+      <widget href="ui/SingleExecutionSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOpQIAEembuNUueTsgQA" name="SingleInteraction" sectionFile="ui/SingleInteraction.xwt">
+      <widget href="ui/SingleInteraction.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOpgIAEembuNUueTsgQA" name="SingleInteractionFragment" sectionFile="ui/SingleInteractionFragment.xwt">
+      <widget href="ui/SingleInteractionFragment.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOpwIAEembuNUueTsgQA" name="SingleInteractionUse" sectionFile="ui/SingleInteractionUse.xwt">
+      <widget href="ui/SingleInteractionUse.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOqAIAEembuNUueTsgQA" name="SingleLifeline" sectionFile="ui/SingleLifeline.xwt">
+      <widget href="ui/SingleLifeline.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOqQIAEembuNUueTsgQA" name="SingleMessage" sectionFile="ui/SingleMessage.xwt">
+      <widget href="ui/SingleMessage.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOqgIAEembuNUueTsgQA" name="SingleMessageEnd" sectionFile="ui/SingleMessageEnd.xwt">
+      <widget href="ui/SingleMessageEnd.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOqwIAEembuNUueTsgQA" name="SingleMessageOccurrenceSpecification" sectionFile="ui/SingleMessageOccurrenceSpecification.xwt">
+      <widget href="ui/SingleMessageOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOrAIAEembuNUueTsgQA" name="SingleOccurrenceSpecification" sectionFile="ui/SingleOccurrenceSpecification.xwt">
+      <widget href="ui/SingleOccurrenceSpecification.xwt#/"/>
+    </sections>
+    <sections xmi:id="_QadOrQIAEembuNUueTsgQA" name="SingleOpaqueBehavior" sectionFile="ui/SingleOpaqueBehavior.xwt">
+      <widget href="ui/SingleOpaqueBehavior.xwt#/"/>
+    </sections>
   </tabs>
   <tabs xmi:id="_vMwxgP8IEeif09Qs_5sVbA" label="Constraints" id="uml-light-constraints" category="org.eclipse.papyrus" image="" priority="11">
     <sections xmi:id="_vMwxgf8IEeif09Qs_5sVbA" name="SingleOperationConstraints" sectionFile="ui/SingleOperationConstraints.xwt">
       <widget href="ui/SingleOperationConstraints.xwt#/"/>
+    </sections>
+    <sections xmi:id="_y3BpEAIDEem-9ZNT6Xm3MA" name="SingleBehaviorConstraints" sectionFile="ui/SingleBehaviorConstraints.xwt">
+      <widget href="ui/SingleBehaviorConstraints.xwt#/"/>
     </sections>
   </tabs>
   <views xmi:id="_69ur3KDJEeSZxfCXzZz3-w" name="SingleFinalState" sections="_69cXZ6DJEeSZxfCXzZz3-w" automaticContext="true">
@@ -792,6 +885,186 @@
     <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_3OPMY_7xEeioQ5IXbg1K0w" name="isSingleTypedElement">
       <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
       <properties xsi:type="constraints:ValueProperty" xmi:id="_3OPMZP7xEeioQ5IXbg1K0w" name="umlClassName" value="TypedElement"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1oAIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleActionExecutionSpecification" sections="_QadOkAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1oQIAEembuNUueTsgQA" name="isMultipleActionExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1ogIAEembuNUueTsgQA" name="umlClassName" value="ActionExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1owIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleBehavior" sections="_QadOkQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1pAIAEembuNUueTsgQA" name="isMultipleBehavior">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1pQIAEembuNUueTsgQA" name="umlClassName" value="Behavior"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1pgIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleBehaviorExecutionSpecification" sections="_QadOkgIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1pwIAEembuNUueTsgQA" name="isMultipleBehaviorExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1qAIAEembuNUueTsgQA" name="umlClassName" value="BehaviorExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1qQIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleDestructionOccurrenceSpecification" sections="_QadOkwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1qgIAEembuNUueTsgQA" name="isMultipleDestructionOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1qwIAEembuNUueTsgQA" name="umlClassName" value="DestructionOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1rAIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleExecutionOccurrenceSpecification" sections="_QadOlAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1rQIAEembuNUueTsgQA" name="isMultipleExecutionOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1rgIAEembuNUueTsgQA" name="umlClassName" value="ExecutionOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1rwIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleExecutionSpecification" sections="_QadOlQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1sAIAEembuNUueTsgQA" name="isMultipleExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1sQIAEembuNUueTsgQA" name="umlClassName" value="ExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1sgIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleInteraction" sections="_QadOlgIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1swIAEembuNUueTsgQA" name="isMultipleInteraction">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1tAIAEembuNUueTsgQA" name="umlClassName" value="Interaction"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1tQIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleInteractionFragment" sections="_QadOlwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1tgIAEembuNUueTsgQA" name="isMultipleInteractionFragment">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1twIAEembuNUueTsgQA" name="umlClassName" value="InteractionFragment"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1uAIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleInteractionUse" sections="_QadOmAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1uQIAEembuNUueTsgQA" name="isMultipleInteractionUse">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1ugIAEembuNUueTsgQA" name="umlClassName" value="InteractionUse"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1uwIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleLifeline" sections="_QadOmQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1vAIAEembuNUueTsgQA" name="isMultipleLifeline">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1vQIAEembuNUueTsgQA" name="umlClassName" value="Lifeline"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1vgIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleMessage" sections="_QadOmgIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1vwIAEembuNUueTsgQA" name="isMultipleMessage">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1wAIAEembuNUueTsgQA" name="umlClassName" value="Message"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1wQIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleMessageEnd" sections="_QadOmwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1wgIAEembuNUueTsgQA" name="isMultipleMessageEnd">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1wwIAEembuNUueTsgQA" name="umlClassName" value="MessageEnd"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1xAIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleMessageOccurrenceSpecification" sections="_QadOnAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1xQIAEembuNUueTsgQA" name="isMultipleMessageOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1xgIAEembuNUueTsgQA" name="umlClassName" value="MessageOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1xwIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleOccurrenceSpecification" sections="_QadOnQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1yAIAEembuNUueTsgQA" name="isMultipleOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1yQIAEembuNUueTsgQA" name="umlClassName" value="OccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1ygIAEembuNUueTsgQA" elementMultiplicity="-1" name="MultipleOpaqueBehavior" sections="_QadOngIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1ywIAEembuNUueTsgQA" name="isMultipleOpaqueBehavior">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1zAIAEembuNUueTsgQA" name="umlClassName" value="OpaqueBehavior"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad1zQIAEembuNUueTsgQA" name="SingleActionExecutionSpecification" sections="_QadOnwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1zgIAEembuNUueTsgQA" name="isSingleActionExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1zwIAEembuNUueTsgQA" name="umlClassName" value="ActionExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad10AIAEembuNUueTsgQA" name="SingleBehavior" sections="_QadOoAIAEembuNUueTsgQA _y3BpEAIDEem-9ZNT6Xm3MA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad10QIAEembuNUueTsgQA" name="isSingleBehavior">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad10gIAEembuNUueTsgQA" name="umlClassName" value="Behavior"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad10wIAEembuNUueTsgQA" name="SingleBehaviorExecutionSpecification" sections="_QadOoQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad11AIAEembuNUueTsgQA" name="isSingleBehaviorExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad11QIAEembuNUueTsgQA" name="umlClassName" value="BehaviorExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad11gIAEembuNUueTsgQA" name="SingleDestructionOccurrenceSpecification" sections="_QadOogIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad11wIAEembuNUueTsgQA" name="isSingleDestructionOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad12AIAEembuNUueTsgQA" name="umlClassName" value="DestructionOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad12QIAEembuNUueTsgQA" name="SingleExecutionOccurrenceSpecification" sections="_QadOowIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad12gIAEembuNUueTsgQA" name="isSingleExecutionOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad12wIAEembuNUueTsgQA" name="umlClassName" value="ExecutionOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad13AIAEembuNUueTsgQA" name="SingleExecutionSpecification" sections="_QadOpAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad13QIAEembuNUueTsgQA" name="isSingleExecutionSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad13gIAEembuNUueTsgQA" name="umlClassName" value="ExecutionSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad13wIAEembuNUueTsgQA" name="SingleInteraction" sections="_QadOpQIAEembuNUueTsgQA _y3BpEAIDEem-9ZNT6Xm3MA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad14AIAEembuNUueTsgQA" name="isSingleInteraction">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad14QIAEembuNUueTsgQA" name="umlClassName" value="Interaction"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad14gIAEembuNUueTsgQA" name="SingleInteractionFragment" sections="_QadOpgIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad14wIAEembuNUueTsgQA" name="isSingleInteractionFragment">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad15AIAEembuNUueTsgQA" name="umlClassName" value="InteractionFragment"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad15QIAEembuNUueTsgQA" name="SingleInteractionUse" sections="_QadOpwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad15gIAEembuNUueTsgQA" name="isSingleInteractionUse">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad15wIAEembuNUueTsgQA" name="umlClassName" value="InteractionUse"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad16AIAEembuNUueTsgQA" name="SingleLifeline" sections="_QadOqAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad16QIAEembuNUueTsgQA" name="isSingleLifeline">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad16gIAEembuNUueTsgQA" name="umlClassName" value="Lifeline"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad16wIAEembuNUueTsgQA" name="SingleMessage" sections="_QadOqQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad17AIAEembuNUueTsgQA" name="isSingleMessage">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad17QIAEembuNUueTsgQA" name="umlClassName" value="Message"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad17gIAEembuNUueTsgQA" name="SingleMessageEnd" sections="_QadOqgIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad17wIAEembuNUueTsgQA" name="isSingleMessageEnd">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad18AIAEembuNUueTsgQA" name="umlClassName" value="MessageEnd"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad18QIAEembuNUueTsgQA" name="SingleMessageOccurrenceSpecification" sections="_QadOqwIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad18gIAEembuNUueTsgQA" name="isSingleMessageOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad18wIAEembuNUueTsgQA" name="umlClassName" value="MessageOccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad19AIAEembuNUueTsgQA" name="SingleOccurrenceSpecification" sections="_QadOrAIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad19QIAEembuNUueTsgQA" name="isSingleOccurrenceSpecification">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad19gIAEembuNUueTsgQA" name="umlClassName" value="OccurrenceSpecification"/>
+    </constraints>
+  </views>
+  <views xmi:id="_Qad19wIAEembuNUueTsgQA" name="SingleOpaqueBehavior" sections="_QadOrQIAEembuNUueTsgQA" automaticContext="true">
+    <constraints xsi:type="constraints:SimpleConstraint" xmi:id="_Qad1-AIAEembuNUueTsgQA" name="isSingleOpaqueBehavior">
+      <constraintType href="ppe:/environment/org.eclipse.papyrus.uml.properties/Model/Environment.xmi#//@constraintTypes.0"/>
+      <properties xsi:type="constraints:ValueProperty" xmi:id="_Qad1-QIAEembuNUueTsgQA" name="umlClassName" value="OpaqueBehavior"/>
     </constraints>
   </views>
   <dataContexts xmi:id="_690xgaDJEeSZxfCXzZz3-w" name="UML" label="UML">

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleActionExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleActionExecutionSpecification.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleBehavior.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleBehavior.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleBehaviorExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleBehaviorExecutionSpecification.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDestructionOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleDestructionOccurrenceSpecification.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExecutionOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExecutionOccurrenceSpecification.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleExecutionSpecification.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteraction.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteraction.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteractionFragment.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteractionFragment.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteractionUse.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleInteractionUse.xwt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLifeline.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleLifeline.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessage.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessage.xwt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:Message:messageSort"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessageEnd.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessageEnd.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets" xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessageOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleMessageOccurrenceSpecification.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOccurrenceSpecification.xwt
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOpaqueBehavior.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/MultipleOpaqueBehavior.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleActionExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleActionExecutionSpecification.xwt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:start"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:finish"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:ActionExecutionSpecification:action"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehavior.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehavior.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Behavior:specification"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehaviorConstraints.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehaviorConstraints.xwt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:umlXtext="clr-namespace:org.eclipse.papyrus.uml.properties.xtext"
+	xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:xtext="clr-namespace:org.eclipse.papyrus.infra.widgets.xtext.creation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="1"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Behavior:bodyCondition"></ppe:ReferenceDialog>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Behavior:precondition"></ppe:MultiReference>
+		<ppe:MultiReference input="{Binding}"
+			property="UML:Behavior:postcondition"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehaviorExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleBehaviorExecutionSpecification.xwt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:start"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:finish"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:BehaviorExecutionSpecification:behavior"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDestructionOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDestructionOccurrenceSpecification.xwt
@@ -12,4 +12,10 @@
 		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
 		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
 	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:MessageEnd:message" readOnly="true"></ppe:ReferenceDialog>
+	</Composite>
 </Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDestructionOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleDestructionOccurrenceSpecification.xwt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExecutionOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExecutionOccurrenceSpecification.xwt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionOccurrenceSpecification:execution"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExecutionSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleExecutionSpecification.xwt
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:start"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:ExecutionSpecification:finish"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteraction.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteraction.xwt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Behavior:specification"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteractionFragment.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteractionFragment.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation" xmlns:x="http://www.eclipse.org/xwt"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteractionUse.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleInteractionUse.xwt
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+		<ppe:ReferenceDialog property="UML:InteractionUse:refersTo"
+			input="{Binding}"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLifeline.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleLifeline.xwt
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Lifeline:represents"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessage.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessage.xwt
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:Message:sendEvent"></ppe:ReferenceDialog>
+		<ppe:ReferenceDialog input="{Binding}" readOnly="true"
+			property="UML:Message:receiveEvent"></ppe:ReferenceDialog>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:EnumCombo input="{Binding}" property="UML:Message:messageSort"></ppe:EnumCombo>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:Message:signature"></ppe:ReferenceDialog>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:MultiReference input="{Binding}" property="UML:Message:argument"></ppe:MultiReference>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessageEnd.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessageEnd.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:MessageEnd:message" readOnly="true"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessageOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleMessageOccurrenceSpecification.xwt
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:j="clr-namespace:java.lang" xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}" property="UML:MessageEnd:message" readOnly="true"></ppe:ReferenceDialog>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOccurrenceSpecification.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOccurrenceSpecification.xwt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:x="http://www.eclipse.org/xwt" xmlns:j="clr-namespace:java.lang"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns="http://www.eclipse.org/xwt/presentation">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOpaqueBehavior.xwt
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/context/ui/SingleOpaqueBehavior.xwt
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Composite xmlns="http://www.eclipse.org/xwt/presentation"
+	xmlns:j="clr-namespace:java.lang" xmlns:ppe="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets"
+	xmlns:ppel="clr-namespace:org.eclipse.papyrus.infra.properties.ui.widgets.layout"
+	xmlns:uml="clr-namespace:org.eclipse.papyrus.uml.properties.widgets"
+	xmlns:x="http://www.eclipse.org/xwt">
+	<Composite.layout>
+		<ppel:PropertiesLayout></ppel:PropertiesLayout>
+	</Composite.layout>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:name"></ppe:StringEditor>
+		<ppe:StringEditor input="{Binding}" property="UML:NamedElement:label"></ppe:StringEditor>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout numColumns="2"></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:BooleanRadio input="{Binding}" property="UML:Classifier:isAbstract"></ppe:BooleanRadio>
+		<ppe:EnumCombo input="{Binding}" property="UML:NamedElement:visibility"></ppe:EnumCombo>
+	</Composite>
+	<Composite>
+		<Composite.layout>
+			<ppel:PropertiesLayout></ppel:PropertiesLayout>
+		</Composite.layout>
+		<ppe:ReferenceDialog input="{Binding}"
+			property="UML:Behavior:specification"></ppe:ReferenceDialog>
+		<uml:ExpressionEditor input="{Binding}"
+			property="UML:OpaqueBehavior:language"></uml:ExpressionEditor>
+	</Composite>
+</Composite>

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/UMLLightSubset.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/UMLLightSubset.java
@@ -94,7 +94,6 @@ public class UMLLightSubset {
 		case UMLPackage.PACKAGE:
 		case UMLPackage.PACKAGE_IMPORT:
 		case UMLPackage.DEPENDENCY:
-		case UMLPackage.COMMENT:
 			return true;
 		// Class Diagram concepts
 		case UMLPackage.CLASS:
@@ -153,6 +152,19 @@ public class UMLLightSubset {
 		case UMLPackage.BEHAVIOR_EXECUTION_SPECIFICATION:
 		case UMLPackage.INTERACTION_USE:
 		case UMLPackage.OPAQUE_BEHAVIOR:
+			return true;
+		// Common concepts:
+		case UMLPackage.LITERAL_BOOLEAN:
+		case UMLPackage.LITERAL_STRING:
+		case UMLPackage.LITERAL_INTEGER:
+		case UMLPackage.LITERAL_UNLIMITED_NATURAL:
+		case UMLPackage.LITERAL_REAL:
+		case UMLPackage.LITERAL_NULL:
+		case UMLPackage.INSTANCE_VALUE:
+		case UMLPackage.COMMENT:
+		case UMLPackage.CONSTRAINT:
+		case UMLPackage.OPAQUE_EXPRESSION:
+		case UMLPackage.EXPRESSION:
 			return true;
 		default:
 			return false;

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/UMLLightSubset.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/UMLLightSubset.java
@@ -1,0 +1,161 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal;
+
+import static java.util.Collections.unmodifiableSet;
+import static java.util.EnumSet.complementOf;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.uml2.uml.MessageSort;
+import org.eclipse.uml2.uml.PseudostateKind;
+import org.eclipse.uml2.uml.UMLPackage;
+
+/**
+ * A provider of subsetting functions for the <em>UML</em> metamodel to
+ * determine what is included in the <em>UML Light</em> dialect.
+ */
+public class UMLLightSubset {
+
+	private static final UMLLightSubset INSTANCE = new UMLLightSubset();
+
+	private final Set<MessageSort> messageSorts = unmodifiableSet(
+			complementOf(EnumSet.of(MessageSort.ASYNCH_SIGNAL_LITERAL)));
+
+	private final Set<PseudostateKind> pseudostateKinds = unmodifiableSet(EnumSet.of(PseudostateKind.INITIAL_LITERAL,
+			PseudostateKind.CHOICE_LITERAL, PseudostateKind.JUNCTION_LITERAL));
+
+	/**
+	 * Initializes me.
+	 */
+	public UMLLightSubset() {
+		super();
+	}
+
+	public static UMLLightSubset getInstance() {
+		return INSTANCE;
+	}
+
+	/**
+	 * Query the subset of an enumeration that are the values recognized in <em>UML
+	 * Light</em>.
+	 * 
+	 * @param enumType an enumeration
+	 * @return its <em>UML Light</em> values
+	 */
+	@SuppressWarnings("unchecked") // We actually do check
+	public <E extends Enum<E>> Set<E> getValues(Class<E> enumType) {
+		if (enumType == PseudostateKind.class) {
+			return (Set<E>) pseudostateKinds;
+		} else if (enumType == MessageSort.class) {
+			return (Set<E>) messageSorts;
+		} else {
+			return unmodifiableSet(EnumSet.allOf(enumType));
+		}
+	}
+
+	/**
+	 * Obtain a predicate that selects the valid metaclasses (as represented by
+	 * {@code EClass}) in the <em>UML Light</em> dialect.
+	 * 
+	 * @return the metaclass filter
+	 */
+	public Predicate<EClass> getMetaclassFilter() {
+		return this::isUMLLight;
+	}
+
+	/**
+	 * Query whether a metaclass (as represented by an EMF {@code eclass}) supported
+	 * in the <em>UML Light</em> dialect.
+	 * 
+	 * @param eclass a metaclass
+	 * @return whether it is a <em>UML Light</em> metaclass
+	 */
+	public boolean isUMLLight(EClass eclass) {
+		if (eclass.getEPackage() != UMLPackage.eINSTANCE) {
+			return false;
+		}
+
+		switch (eclass.getClassifierID()) {
+		// Package Diagram concepts
+		case UMLPackage.MODEL:
+		case UMLPackage.PACKAGE:
+		case UMLPackage.PACKAGE_IMPORT:
+		case UMLPackage.DEPENDENCY:
+		case UMLPackage.COMMENT:
+			return true;
+		// Class Diagram concepts
+		case UMLPackage.CLASS:
+		case UMLPackage.DATA_TYPE:
+		case UMLPackage.ENUMERATION:
+		case UMLPackage.PRIMITIVE_TYPE:
+		case UMLPackage.ENUMERATION_LITERAL:
+		case UMLPackage.PROPERTY:
+		case UMLPackage.ASSOCIATION:
+		case UMLPackage.ASSOCIATION_CLASS:
+		case UMLPackage.OPERATION:
+		case UMLPackage.PARAMETER:
+		case UMLPackage.GENERALIZATION:
+		case UMLPackage.INTERFACE_REALIZATION:
+		case UMLPackage.REALIZATION:
+			return true;
+		// Use Case Diagram concepts
+		case UMLPackage.ACTOR:
+		case UMLPackage.USE_CASE:
+		case UMLPackage.INCLUDE:
+		case UMLPackage.EXTEND:
+		case UMLPackage.EXTENSION_POINT:
+			return true;
+		// State Machine Diagram concepts
+		case UMLPackage.STATE_MACHINE:
+		case UMLPackage.STATE:
+		case UMLPackage.FINAL_STATE:
+		case UMLPackage.PSEUDOSTATE:
+		case UMLPackage.TRANSITION:
+			return true;
+		// Activity Diagram concepts
+		case UMLPackage.ACTIVITY:
+		case UMLPackage.INITIAL_NODE:
+		case UMLPackage.FLOW_FINAL_NODE:
+		case UMLPackage.ACTIVITY_FINAL_NODE:
+		case UMLPackage.DECISION_NODE:
+		case UMLPackage.MERGE_NODE:
+		case UMLPackage.FORK_NODE:
+		case UMLPackage.JOIN_NODE:
+		case UMLPackage.OPAQUE_ACTION:
+		case UMLPackage.CALL_BEHAVIOR_ACTION:
+		case UMLPackage.CALL_OPERATION_ACTION:
+		case UMLPackage.ACCEPT_EVENT_ACTION:
+		case UMLPackage.INPUT_PIN:
+		case UMLPackage.OUTPUT_PIN:
+		case UMLPackage.VALUE_PIN:
+		case UMLPackage.CONTROL_FLOW:
+			return true;
+		// Sequence Diagram concepts:
+		case UMLPackage.INTERACTION:
+		case UMLPackage.LIFELINE:
+		case UMLPackage.MESSAGE:
+		case UMLPackage.MESSAGE_OCCURRENCE_SPECIFICATION:
+		case UMLPackage.EXECUTION_OCCURRENCE_SPECIFICATION:
+		case UMLPackage.ACTION_EXECUTION_SPECIFICATION:
+		case UMLPackage.BEHAVIOR_EXECUTION_SPECIFICATION:
+		case UMLPackage.INTERACTION_USE:
+		case UMLPackage.OPAQUE_BEHAVIOR:
+			return true;
+		default:
+			return false;
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -15,12 +15,14 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.infra.services.semantic;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.papyrus.infra.emf;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.papyrus.uml.properties;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.papyrus.infra.properties.ui;bundle-version="[3.4.0,4.0.0)"
+ org.eclipse.papyrus.infra.properties.ui;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.papyrus.uml.tools
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.newchild;x-internal:=true,
+ org.eclipse.papyrus.umllight.ui.internal.properties;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.widgets.editors;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.properties.widgets

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
@@ -80,4 +80,9 @@ public class Activator extends AbstractUIPlugin {
 	public void log(Throwable exception) {
 		logHelper.error("Uncaught exception", exception); //$NON-NLS-1$
 	}
+
+	public void warn(String message) {
+		logHelper.warn(message);
+	}
+
 }

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/DynamicEnumComboHelper.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/DynamicEnumComboHelper.java
@@ -1,0 +1,152 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.properties;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.databinding.observable.Realm;
+import org.eclipse.core.databinding.observable.value.IObservableValue;
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+import org.eclipse.papyrus.infra.gmfdiag.common.databinding.GMFObservableValue;
+import org.eclipse.papyrus.infra.properties.ui.modelelement.DataSourceChangedEvent;
+import org.eclipse.papyrus.infra.properties.ui.modelelement.EMFModelElement;
+import org.eclipse.papyrus.infra.properties.ui.modelelement.IDataSourceListener;
+import org.eclipse.papyrus.infra.ui.emf.providers.EMFEnumeratorContentProvider;
+import org.eclipse.papyrus.infra.widgets.providers.IStaticContentProvider;
+import org.eclipse.papyrus.umllight.core.internal.UMLLightSubset;
+import org.eclipse.swt.custom.CCombo;
+import org.eclipse.swt.widgets.Control;
+
+/**
+ * The {@code EnumCombo} property editor does not support different elements
+ * having different subsets of the enum values presented in the choice of
+ * values. A naïve attempt in the {@link EMFModelElement} simply to return
+ * different values for different source elements results in refresh on
+ * selection change unsetting the property on an inconsistency between the
+ * values allowed for the initial selection as compared to the new selection.
+ * This class works around that by direct manipulation of the {@link CCombo}
+ * underlying the editor's viewer.
+ */
+class DynamicEnumComboHelper<E extends Enum<E> & Enumerator> implements IDataSourceListener {
+
+	private final EMFModelElement element;
+	private final EStructuralFeature feature;
+	private final Class<E> enumType;
+	private final Function<? super EObject, ? extends Set<E>> allowedValuesFunction;
+
+	private IStaticContentProvider contentProvider;
+	private ComboViewer comboViewer;
+
+	/**
+	 * Initializes me with the {@code element} that I help.
+	 * 
+	 * @param feature               the structural feature that I help
+	 * @param allowedValuesFunction the dynamic computation of the values allowed
+	 *                              for the model element
+	 */
+	@SuppressWarnings("unchecked")
+	DynamicEnumComboHelper(EMFModelElement element, EStructuralFeature feature,
+			Function<? super EObject, ? extends Set<E>> allowedValuesFunction) {
+		super();
+
+		this.element = element;
+		this.feature = feature;
+		this.enumType = (Class<E>) feature.getEType().getInstanceClass().asSubclass(Enum.class);
+		this.allowedValuesFunction = allowedValuesFunction;
+	}
+
+	@SuppressWarnings("unchecked")
+	IObservableValue<E> getObservableValue() {
+		return new GMFObservableValue(Realm.getDefault(), element.getSource(), feature, element.getDomain()) {
+			@Override
+			protected void doSetValue(Object value) {
+				// We will be setting the selected value in the viewer to the current
+				// value of the new source when the workbench selection changes. This
+				// triggers the data binding but we don't want to execute a no-op command
+				// for that as the superclass would do
+				if (!Objects.equals(value, doGetValue())) {
+					super.doSetValue(value);
+				}
+			}
+		};
+	}
+
+	IStaticContentProvider getContentProvider() {
+		if (contentProvider == null) {
+			contentProvider = new EMFEnumeratorContentProvider(feature) {
+
+				private final List<?> values = UMLLightSubset.getInstance().getValues(enumType).stream()
+						.map(Enumerator.class::cast).sorted(Comparator.comparing(Enumerator::getLiteral))
+						.collect(Collectors.toList());
+
+				@Override
+				public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+					super.inputChanged(viewer, oldInput, newInput);
+
+					comboViewer = (ComboViewer) viewer;
+
+					if (comboViewer != null) {
+						postFilters();
+					}
+				}
+
+				@Override
+				public Object[] getElements() {
+					return values.toArray();
+				}
+
+			};
+		}
+
+		return contentProvider;
+	}
+
+	@Override
+	public void dataSourceChanged(DataSourceChangedEvent event) {
+		if (comboViewer != null) {
+			// Clear any filters to prepare for selection change
+			comboViewer.setFilters();
+			// Prime the viewer's selection with the new source's value of the feature
+			comboViewer.setSelection(new StructuredSelection(element.getSource().eGet(feature)));
+
+			postFilters();
+		}
+	}
+
+	private void postFilters() {
+		Control combo = comboViewer.getControl();
+		EObject source = element.getSource();
+		Set<E> realValues = allowedValuesFunction.apply(source);
+
+		combo.getDisplay().asyncExec(() -> {
+			if (!combo.isDisposed()) {
+				// Set a viewer filter to hide disallowed values
+				comboViewer.setFilters(new ViewerFilter() {
+					public boolean select(Viewer viewer, Object parentElement, Object element) {
+						return realValues.contains(element);
+					}
+				});
+			}
+		});
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightModelElement.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightModelElement.java
@@ -1,0 +1,133 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.properties;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.eclipse.core.databinding.observable.IObservable;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.papyrus.infra.properties.ui.creation.EcorePropertyEditorFactory;
+import org.eclipse.papyrus.infra.properties.ui.modelelement.DataSource;
+import org.eclipse.papyrus.infra.widgets.creation.ReferenceValueFactory;
+import org.eclipse.papyrus.infra.widgets.providers.IStaticContentProvider;
+import org.eclipse.papyrus.uml.properties.modelelement.UMLModelElement;
+import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.MessageSort;
+import org.eclipse.uml2.uml.UMLPackage;
+
+/**
+ * A specific properties view model element façade implementation for <em>UML
+ * Light</em>.
+ */
+public class UMLLightModelElement extends UMLModelElement {
+
+	private final DynamicEnumComboHelper<MessageSort> messageSortHelper;
+
+	/**
+	 * Initializes me with my {@code source} element and contextual editing
+	 * {@code domain}.
+	 * 
+	 * @param source the source UML model element
+	 * @param domain the contextual editing domain
+	 */
+	public UMLLightModelElement(EObject source, EditingDomain domain) {
+		super(source, domain);
+
+		messageSortHelper = new DynamicEnumComboHelper<>(this, UMLPackage.Literals.MESSAGE__MESSAGE_SORT,
+				this::getAllowedMessageSorts);
+	}
+
+	@Override
+	public IObservable doGetObservable(String propertyPath) {
+		EStructuralFeature feature = getFeature(propertyPath);
+
+		if (feature == UMLPackage.Literals.MESSAGE__MESSAGE_SORT) {
+			// We don't support all of the message sorts
+			return messageSortHelper.getObservableValue();
+		} else {
+			return super.doGetObservable(propertyPath);
+		}
+	}
+
+	@Override
+	public IStaticContentProvider getContentProvider(String propertyPath) {
+		EStructuralFeature feature = getFeature(propertyPath);
+
+		if (feature == UMLPackage.Literals.MESSAGE__MESSAGE_SORT) {
+			// We don't support all of the message sorts
+			return messageSortHelper.getContentProvider();
+		} else {
+			return super.getContentProvider(propertyPath);
+		}
+	}
+
+	private Set<MessageSort> getAllowedMessageSorts(EObject source) {
+		Message message = (Message) source;
+		switch (message.getMessageSort()) {
+		case SYNCH_CALL_LITERAL:
+		case ASYNCH_CALL_LITERAL:
+			// Can switch freely between these sorts
+			return EnumSet.of(MessageSort.SYNCH_CALL_LITERAL, MessageSort.ASYNCH_CALL_LITERAL);
+		default:
+			// It doesn't make sense to change the sort of a reply, create, or delete
+			return EnumSet.of(message.getMessageSort());
+		}
+	}
+
+	@Override
+	public ReferenceValueFactory getValueFactory(String propertyPath) {
+		ReferenceValueFactory result = super.getValueFactory(propertyPath);
+
+		if (result == null || !(result instanceof EcorePropertyEditorFactory)) {
+			return result;
+		}
+
+		// Copy with filtering of creatable EClasses
+		UMLLightPropertyEditorFactory factory = new UMLLightPropertyEditorFactory((EcorePropertyEditorFactory) result);
+
+		EStructuralFeature feature = getFeature(propertyPath);
+		if (feature == UMLPackage.Literals.MESSAGE__SIGNATURE) {
+			// We don't support signals, so there's only one choice
+			factory.setEClass(UMLPackage.Literals.OPERATION);
+			result = factory;
+		}
+
+		result = factory;
+		return result;
+	}
+
+	@Override
+	public void setDataSource(DataSource source) {
+		if (dataSource != null) {
+			dataSource.removeDataSourceListener(messageSortHelper);
+		}
+
+		super.setDataSource(source);
+
+		if (dataSource != null) {
+			dataSource.addDataSourceListener(messageSortHelper);
+		}
+	}
+
+	@Override
+	public void dispose() {
+		if (dataSource != null) {
+			dataSource.removeDataSourceListener(messageSortHelper);
+		}
+
+		super.dispose();
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightModelElementFactory.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightModelElementFactory.java
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.properties;
+
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.papyrus.infra.emf.utils.EMFHelper;
+import org.eclipse.papyrus.infra.properties.contexts.DataContextElement;
+import org.eclipse.papyrus.uml.properties.modelelement.UMLModelElementFactory;
+import org.eclipse.papyrus.uml.tools.utils.UMLUtil;
+import org.eclipse.papyrus.umllight.ui.internal.Activator;
+import org.eclipse.uml2.uml.Element;
+
+/**
+ * Factory for the specific <em>UML Light</em> implementation of the properties
+ * view model element façade.
+ */
+public class UMLLightModelElementFactory extends UMLModelElementFactory {
+
+	/**
+	 * Initializes me.
+	 */
+	public UMLLightModelElementFactory() {
+		super();
+	}
+
+	@Override
+	protected UMLLightModelElement doCreateFromSource(Object source, DataContextElement context) {
+		Element umlSource = UMLUtil.resolveUMLElement(source);
+		if (umlSource == null) {
+			Activator.getDefault().warn("Cannot resolve the selection to a UML Element"); //$NON-NLS-1$
+			return null;
+		}
+
+		EditingDomain domain = EMFHelper.resolveEditingDomain(umlSource);
+		return new UMLLightModelElement(umlSource, domain);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightPropertyEditorFactory.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightPropertyEditorFactory.java
@@ -1,0 +1,105 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.properties;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.papyrus.infra.properties.ui.creation.EcorePropertyEditorFactory;
+import org.eclipse.papyrus.uml.properties.creation.UMLPropertyEditorFactory;
+import org.eclipse.papyrus.umllight.core.internal.UMLLightSubset;
+import org.eclipse.papyrus.umllight.ui.internal.Activator;
+
+/**
+ * Custom property editor factory that supports filtering of the metaclasses
+ * that may be instantiated for creation of new elements, to the
+ * {@linkplain UMLLightSubset subset} recognized by <em>UML Light</em>.
+ */
+public class UMLLightPropertyEditorFactory extends UMLPropertyEditorFactory {
+
+	private static final ConcurrentHashMap<String, Function<EcorePropertyEditorFactory, ?>> fieldAccessors = new ConcurrentHashMap<>();
+
+	/**
+	 * Initializes me from the {@code original} to copy.
+	 * 
+	 * @param original the property editor factory to copy
+	 */
+	public UMLLightPropertyEditorFactory(EcorePropertyEditorFactory original) {
+		super(get(original, "referenceIn")); //$NON-NLS-1$
+
+		this.type = get(original, "type"); //$NON-NLS-1$
+		this.eClass = get(original, "eClass"); //$NON-NLS-1$
+		this.nsUri = get(original, "nsUri"); //$NON-NLS-1$
+		this.className = get(original, "className"); //$NON-NLS-1$
+		this.containerContentProvider = get(original, "containerContentProvider"); //$NON-NLS-1$
+		this.referenceContentProvider = get(original, "referenceContentProvider"); //$NON-NLS-1$
+		this.containerLabelProvider = get(original, "containerLabelProvider"); //$NON-NLS-1$
+		this.referenceLabelProvider = get(original, "referenceLabelProvider"); //$NON-NLS-1$
+		this.labelProviderService = get(original, "labelProviderService"); //$NON-NLS-1$
+	}
+
+	@Override
+	protected List<EClass> getAvailableEClasses() {
+		List<EClass> result = super.getAvailableEClasses();
+		result.removeIf(UMLLightSubset.getInstance().getMetaclassFilter().negate());
+		return result;
+	}
+
+	/**
+	 * Set a specific metaclass to instantiate, or {@code null} to infer from the
+	 * reference type or require user selection.
+	 * 
+	 * @param eClass the metaclass to instantiate, or {@code null}
+	 */
+	void setEClass(EClass eClass) {
+		this.eClass = null;
+		this.className = null;
+		this.nsUri = null;
+
+		if (eClass != null) {
+			setNsUri(eClass.getEPackage().getNsURI());
+			setClassName(eClass.getName());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T get(EcorePropertyEditorFactory original, String field) {
+		return (T) getField(original, field).apply(original);
+	}
+
+	private static Function<EcorePropertyEditorFactory, ?> getField(EcorePropertyEditorFactory target, String name) {
+		return fieldAccessors.computeIfAbsent(name, UMLLightPropertyEditorFactory::access);
+	}
+
+	private static Function<EcorePropertyEditorFactory, ?> access(String fieldName) {
+		try {
+			Field field = EcorePropertyEditorFactory.class.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			return owner -> {
+				try {
+					return field.get(owner);
+				} catch (Exception e) {
+					Activator.getDefault().log(e);
+					// Don't try this again
+					fieldAccessors.put(fieldName, __ -> null);
+					return null;
+				}
+			};
+		} catch (Exception e) {
+			Activator.getDefault().log(e);
+			return __ -> null;
+		}
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightPropertyEditorFactory.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/properties/UMLLightPropertyEditorFactory.java
@@ -12,15 +12,20 @@
 package org.eclipse.papyrus.umllight.ui.internal.properties;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.papyrus.infra.properties.ui.creation.EcorePropertyEditorFactory;
 import org.eclipse.papyrus.uml.properties.creation.UMLPropertyEditorFactory;
 import org.eclipse.papyrus.umllight.core.internal.UMLLightSubset;
 import org.eclipse.papyrus.umllight.ui.internal.Activator;
+import org.eclipse.uml2.uml.UMLPackage;
 
 /**
  * Custom property editor factory that supports filtering of the metaclasses
@@ -30,6 +35,15 @@ import org.eclipse.papyrus.umllight.ui.internal.Activator;
 public class UMLLightPropertyEditorFactory extends UMLPropertyEditorFactory {
 
 	private static final ConcurrentHashMap<String, Function<EcorePropertyEditorFactory, ?>> fieldAccessors = new ConcurrentHashMap<>();
+
+	private static final Set<EReference> NON_EDITABLE_REFERENCES = new HashSet<>(
+			Arrays.asList(UMLPackage.Literals.MESSAGE__SEND_EVENT, //
+					UMLPackage.Literals.MESSAGE__RECEIVE_EVENT, //
+					UMLPackage.Literals.MESSAGE_END__MESSAGE, //
+					UMLPackage.Literals.EXECUTION_SPECIFICATION__START, //
+					UMLPackage.Literals.EXECUTION_SPECIFICATION__FINISH, //
+					UMLPackage.Literals.EXECUTION_OCCURRENCE_SPECIFICATION__EXECUTION //
+			));
 
 	/**
 	 * Initializes me from the {@code original} to copy.
@@ -55,6 +69,16 @@ public class UMLLightPropertyEditorFactory extends UMLPropertyEditorFactory {
 		List<EClass> result = super.getAvailableEClasses();
 		result.removeIf(UMLLightSubset.getInstance().getMetaclassFilter().negate());
 		return result;
+	}
+
+	@Override
+	public boolean canCreateObject() {
+		return super.canCreateObject() && !NON_EDITABLE_REFERENCES.contains(referenceIn);
+	}
+
+	@Override
+	public boolean canEdit() {
+		return super.canEdit() && !NON_EDITABLE_REFERENCES.contains(referenceIn);
 	}
 
 	/**


### PR DESCRIPTION
Implement the property views for elements in the _UML Light Sequence Diagram_.  This includes a custom `ModelElement` implementation that provides for filtering of

- enumeration values that are supported in the language subset for enumerations
- `EClass`es that may be instantiated for creation of new elements via the green ➕ button

The former is applied to filtering of allowed `MessageSort` values for messages.  The latter is implemented generically for all of the diagrams.

Any other customization of the edit behaviour in the **Properties View** can be integrated in this `UMLLightModelElement`, possibly with the assistance of more custom editor widgets like the custom multiplicity editor.