### PR TITLE
Fix #68 Disable UML Metamodel context

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.umllight.core;bundle-version="[0.0.1,1.0.0)",
  org.eclipse.papyrus.infra.newchild;bundle-version="[4.0.0,5.0.0)",
  org.eclipse.ui.navigator.resources;bundle-version="[3.6.100,4.0.0)",
- org.eclipse.ui.navigator;bundle-version="[3.7.100,4.0.0)"
+ org.eclipse.ui.navigator;bundle-version="[3.7.100,4.0.0)",
+ org.eclipse.papyrus.views.properties;bundle-version="4.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/plugin.xml
@@ -575,4 +575,10 @@
          </enablement>
       </actionProvider>
    </extension>
+   <extension
+         point="org.eclipse.ui.startup">
+      <startup
+            class="org.eclipse.papyrus.umllight.ui.simplification.internal.Activator$Startup">
+      </startup>
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/Activator.java
@@ -12,7 +12,12 @@
 
 package org.eclipse.papyrus.umllight.ui.simplification.internal;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.papyrus.umllight.ui.simplification.internal.ContextConfigurator.Context;
+import org.eclipse.ui.IStartup;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.ui.progress.UIJob;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -35,13 +40,13 @@ public class Activator extends AbstractUIPlugin {
 
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-
 		plugin = this;
+		configureCreationMenus();
+		ContextConfigurator.disableContext(Context.UML);
 	}
 
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
-
 		super.stop(context);
 	}
 
@@ -54,4 +59,30 @@ public class Activator extends AbstractUIPlugin {
 		return plugin;
 	}
 
+	private void configureCreationMenus() {
+		// Do this on the UI thread because that's the context in which the creation
+		// menu registry is generally accessed
+		new UIJob("Initializing creation menus") {
+
+			@Override
+			public IStatus runInUIThread(IProgressMonitor monitor) {
+				return CreationMenuCleaner.clean();
+			}
+		}.schedule();
+	}
+	
+	// 
+	  // Nested types 
+	  // 
+	 
+	  /** 
+	   * An early startup hook that cleans the creation menu registry disables unwanted contexts. 
+	   */ 
+	  public static class Startup implements IStartup { 
+	    @Override 
+	    public void earlyStartup() { 
+	      // Nothing really to do but kick the activator 
+	      Activator.getDefault(); 
+	    } 
+	  }
 }

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/Activator.java
@@ -42,7 +42,7 @@ public class Activator extends AbstractUIPlugin {
 		super.start(context);
 		plugin = this;
 		configureCreationMenus();
-		ContextConfigurator.disableContext(Context.UML);
+		configureContexts();
 	}
 
 	public void stop(BundleContext context) throws Exception {
@@ -59,6 +59,13 @@ public class Activator extends AbstractUIPlugin {
 		return plugin;
 	}
 
+	private void configureContexts() {
+		if (ContextConfigurator.isEnabled(Context.UML)) {
+			ContextConfigurator.disableContext(Context.UML);
+			ContextConfigurator.enableContext(Context.UML_LIGHT);
+		}
+	}
+
 	private void configureCreationMenus() {
 		// Do this on the UI thread because that's the context in which the creation
 		// menu registry is generally accessed
@@ -70,19 +77,20 @@ public class Activator extends AbstractUIPlugin {
 			}
 		}.schedule();
 	}
-	
-	// 
-	  // Nested types 
-	  // 
-	 
-	  /** 
-	   * An early startup hook that cleans the creation menu registry disables unwanted contexts. 
-	   */ 
-	  public static class Startup implements IStartup { 
-	    @Override 
-	    public void earlyStartup() { 
-	      // Nothing really to do but kick the activator 
-	      Activator.getDefault(); 
-	    } 
-	  }
+
+	//
+	// Nested types
+	//
+
+	/**
+	 * An early startup hook that cleans the creation menu registry disables
+	 * unwanted contexts.
+	 */
+	public static class Startup implements IStartup {
+		@Override
+		public void earlyStartup() {
+			// Nothing really to do but kick the activator
+			Activator.getDefault();
+		}
+	}
 }

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/ContextConfigurator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/ContextConfigurator.java
@@ -22,11 +22,10 @@ public final class ContextConfigurator {
 	}
 
 	/**
-	 * Disables the context with the given name.
-	 * If no such context can be found,
+	 * Disables the context with the given name if the context can be found
 	 * 
-	 * @param name
-	 *            context name
+	 * @param name 
+	 * 			context name
 	 * @see Context
 	 */
 	public static void disableContext(String name) {
@@ -38,6 +37,44 @@ public final class ContextConfigurator {
 				// nothing we can really do
 			}
 		}
+	}
+
+	/**
+	 * Enables the context with the given name if the context can be found
+	 * 
+	 * @param name 
+	 * 			context name
+	 * @see Context
+	 */
+	public static void enableContext(String name) {
+		org.eclipse.papyrus.infra.properties.contexts.Context context = configurationManager.getContext(name);
+		if (context != null) {
+			try {
+				configurationManager.enableContext(context, true);
+			} catch (IllegalStateException e) {
+				// nothing we can really do
+			}
+		}
+	}
+
+	/**
+	 * Queries whether the context with the given name is enabled
+	 * 
+	 * @param name 
+	 * 			context name
+	 * @return whether the context with the given name is enabled. False if no matching context can be found
+	 * @see Context
+	 */
+	public static boolean isEnabled(String name) {
+		org.eclipse.papyrus.infra.properties.contexts.Context context = configurationManager.getContext(name);
+		if (context != null) {
+			try {
+				return configurationManager.isEnabled(context);
+			} catch (IllegalStateException e) {
+				// nothing we can really do
+			}
+		}
+		return false;
 	}
 
 	public interface Context {

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/ContextConfigurator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/ContextConfigurator.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016,2018 EclipseSource Services GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Martin Fleck (EclipseSource) - Initial API and implementation
+ * Tobias Ortmayr - adaptation for UML Light
+ */
+package org.eclipse.papyrus.umllight.ui.simplification.internal;
+
+import org.eclipse.papyrus.views.properties.runtime.ConfigurationManager;
+
+public final class ContextConfigurator {
+
+	/** Configuration manager instance */
+	protected static ConfigurationManager configurationManager = ConfigurationManager.getInstance();
+
+	private ContextConfigurator() {
+	}
+
+	/**
+	 * Disables the context with the given name.
+	 * If no such context can be found,
+	 * 
+	 * @param name
+	 *            context name
+	 * @see Context
+	 */
+	public static void disableContext(String name) {
+		org.eclipse.papyrus.infra.properties.contexts.Context context = configurationManager.getContext(name);
+		if (context != null) {
+			try {
+				configurationManager.disableContext(context, true);
+			} catch (IllegalStateException e) {
+				// nothing we can really do
+			}
+		}
+	}
+
+	public interface Context {
+		/** AdvanceStyle */
+		String ADVANCE_STYLE = "AdvanceStyle";
+
+		/** CSS in Diagrams */
+		String CSS = "CSS";
+
+		/** Customization Models */
+		String CUSTOMIZATION = "Customization";
+
+		/** Diagram Notation */
+		String NOTATION = "notation";
+
+		/** Diagram Styles */
+		String STYLE = "style";
+
+		/** Diagram Synchronization */
+		String SYNCHRONIZATION = "synchronization";
+
+		/** UML Light */
+		String UML_LIGHT = "UML Light";
+
+		/** UML Diagram Symbols */
+		String SYMBOLS = "Symbols";
+
+		/** UML Graphical Notation */
+		String UML_NOTATION = "UMLNotation";
+
+		/** UML Metamodel */
+		String UML = "UML";
+
+		/** UML Profile Externalization */
+		String UML_STEREOTYPE_APPLICATION_EXTERNAL_RESOURCE = "UMLStereotypeApplicationExternalResource";
+
+		/** UML Sequence Diagram Notation */
+		String SEQUENCE_NOTATION = "SequenceNotation";
+	}
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/CreationMenuCleaner.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification/src/org/eclipse/papyrus/umllight/ui/simplification/internal/CreationMenuCleaner.java
@@ -10,7 +10,7 @@
  *   Martin Fleck (EclipseSource) - Initial API and implementation
  *   Christian W. Damus - adaptation for UML Light
  */
-package org.eclipse.papyrus.umllight.ui.internal.newchild;
+package org.eclipse.papyrus.umllight.ui.simplification.internal;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -22,8 +22,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.papyrus.infra.newchild.CreationMenuRegistry;
 import org.eclipse.papyrus.infra.newchild.elementcreationmenumodel.Folder;
-import org.eclipse.papyrus.umllight.ui.internal.Activator;
-import org.eclipse.ui.IStartup;
 
 /**
  * Cleans the creation menu.
@@ -72,20 +70,5 @@ public final class CreationMenuCleaner {
 		}
 
 		return Status.OK_STATUS;
-	}
-
-	//
-	// Nested types
-	//
-
-	/**
-	 * An early startup hook that cleans the creation menu registry.
-	 */
-	public static class Startup implements IStartup {
-		@Override
-		public void earlyStartup() {
-			// Nothing really to do but kick the activator
-			Activator.getDefault();
-		}
 	}
 }

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true,
- org.eclipse.papyrus.umllight.ui.internal.newchild;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.properties;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.widgets.editors;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true,

--- a/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension
-         point="org.eclipse.ui.startup">
-      <startup
-            class="org.eclipse.papyrus.umllight.ui.internal.newchild.CreationMenuCleaner$Startup">
-      </startup>
-   </extension>
    
    <extension point="org.eclipse.ui.newWizards">
 	   <wizard

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/Activator.java
@@ -12,12 +12,8 @@
 
 package org.eclipse.papyrus.umllight.ui.internal;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.papyrus.infra.core.log.LogHelper;
-import org.eclipse.papyrus.umllight.ui.internal.newchild.CreationMenuCleaner;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
-import org.eclipse.ui.progress.UIJob;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -45,8 +41,6 @@ public class Activator extends AbstractUIPlugin {
 
 		logHelper = new LogHelper(context.getBundle());
 		plugin = this;
-
-		configureCreationMenus();
 	}
 
 	public void stop(BundleContext context) throws Exception {
@@ -63,18 +57,6 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public static Activator getDefault() {
 		return plugin;
-	}
-
-	private void configureCreationMenus() {
-		// Do this on the UI thread because that's the context in which the creation
-		// menu registry is generally accessed
-		new UIJob("Initializing creation menus") {
-
-			@Override
-			public IStatus runInUIThread(IProgressMonitor monitor) {
-				return CreationMenuCleaner.clean();
-			}
-		}.schedule();
 	}
 
 	public void log(Throwable exception) {


### PR DESCRIPTION
Extend the `Activator` of the <i>org.eclipse.papyrus.umllight.ui.simplification</i> plugin to hide the default `UML metamodel` context  at runtime via a ContextConfigurator. In addition, the code for cleaning the child creation menus on startup has also been moved to this plugin. 
