### PR TITLE
Fix #71 Adopt 2018-12 release in the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<!-- r2018-12 | photon | oxygen -->
 		<target.eclipseversion>r2018-12</target.eclipseversion>
 		<!-- release | nightly -->
-		<target.branch>nightly</target.branch>
+		<target.branch>release</target.branch>
 		<target.version>0.0.1-SNAPSHOT</target.version>
 	</properties>
 
@@ -141,11 +141,6 @@
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
 							<arch>x86_64</arch>
 						</environment>
 						<environment>
@@ -158,7 +153,6 @@
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
-						<!-- <environment><os>macosx</os><ws>cocoa</ws><arch>x86_64</arch></environment>-->
 					</environments>
 					<target>
 						<artifact>

--- a/targetplatforms/r2018-12-nightly.target
+++ b/targetplatforms/r2018-12-nightly.target
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="UML Light Target Platform - 2018-12 Nightly" sequenceNumber="1541519008">
+<target name="UML Light Target Platform - 2018-12 Nightly" sequenceNumber="1545935568">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.platform.feature.group" version="4.9.0.v20180906-1121"/>
-      <unit id="org.eclipse.sdk.feature.group" version="4.9.0.v20180906-1121"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.9.0.v20180906-1121"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.15.0.v20180906-0745"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.10.0.v20181206-0815"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.10.0.v20181206-1038"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.10.0.v20181206-0815"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.16.0.v20181206-1038"/>
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.100.v20180822-1357"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.100.v20180827-1352"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.200.v20180922-1751"/>
       <unit id="org.eclipse.draw2d" version="3.10.100.201606061308"/>
       <unit id="org.eclipse.gef" version="3.11.0.201606061308"/>
-      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.9.0.v20180911-0720"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.15.0.v20180905-1732"/>
-      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.15.0.v20180722-1116"/>
+      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.9.1.v20181210-1559"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.16.0.v20181206-1055"/>
+      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.16.0.v20181127-0852"/>
       <unit id="org.eclipse.emf.validation.sdk.feature.group" version="1.12.0.201805030717"/>
       <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.emf.workspace.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="1.12.0.201805221301"/>
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.12.0.201806010809"/>
-      <unit id="org.eclipse.uml2.sdk.feature.group" version="5.4.1.v20180903-1400"/>
-      <unit id="org.eclipse.equinox.transforms.hook" version="1.2.200.v20180827-1235"/>
+      <unit id="org.eclipse.uml2.sdk.feature.group" version="5.5.0.v20181203-1331"/>
+      <unit id="org.eclipse.equinox.transforms.hook" version="1.2.300.v20181116-1551"/>
       <unit id="org.eclipse.equinox.transforms.xslt" version="1.0.500.v20180827-1235"/>
-      <repository id="eclipse-platform" location="http://download.eclipse.org/releases/2018-09/"/>
+      <repository id="eclipse-platform" location="http://download.eclipse.org/releases/2018-12/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.egit.feature.group" version="5.1.3.201810200350-r"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.1.3.201810200350-r"/>
-      <repository id="egit" location="http://download.eclipse.org/egit/updates-5.1.3"/>
+      <unit id="org.eclipse.egit.feature.group" version="5.2.0.201812061821-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.2.0.201812061821-r"/>
+      <repository id="egit" location="http://download.eclipse.org/egit/updates-5.2"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
@@ -37,7 +37,7 @@
       <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
       <unit id="com.google.guava.source" version="21.0.0.v20170206-1425"/>
       <unit id="javaewah" version="1.1.6.v20160919-1400"/>
-      <unit id="org.apache.commons.compress" version="1.15.0.v20180119-1613"/>
+      <unit id="org.apache.commons.compress" version="1.18.0.v20181121-2221"/>
       <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="org.kohsuke.args4j" version="2.33.0.v20160323-2218"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
@@ -46,7 +46,7 @@
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
       <unit id="org.objenesis" version="1.0.0.v201505121915"/>
-      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository/"/>
+      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.papyrus.sdk.feature.feature.group" version="0.0.0"/>

--- a/targetplatforms/r2018-12-nightly.tpd
+++ b/targetplatforms/r2018-12-nightly.tpd
@@ -1,6 +1,6 @@
 target "UML Light Target Platform - 2018-12 Nightly" with source requirements
 
-location "http://download.eclipse.org/releases/2018-09/" eclipse-platform {
+location "http://download.eclipse.org/releases/2018-12/" eclipse-platform {
 	org.eclipse.platform.feature.group
 	org.eclipse.sdk.feature.group
 	org.eclipse.rcp.feature.group
@@ -22,13 +22,13 @@ location "http://download.eclipse.org/releases/2018-09/" eclipse-platform {
 	org.eclipse.equinox.transforms.xslt
 }
 
-location "http://download.eclipse.org/egit/updates-5.1.3" egit {
+location "http://download.eclipse.org/egit/updates-5.2" egit {
 	org.eclipse.egit.feature.group
 	org.eclipse.jgit.feature.group
 }
 
 
-location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/S20181031145145/repository/" {
+location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/" {
 	org.apache.commons.io
 	org.apache.commons.io.source
 	com.google.inject

--- a/targetplatforms/r2018-12-release.target
+++ b/targetplatforms/r2018-12-release.target
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="UML Light  Target Platform - Release" sequenceNumber="1539964663">
+<target name="UML Light Target Platform - 2018-12 Release" sequenceNumber="1545935568">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.platform.feature.group" version="4.8.0.v20180611-0656"/>
-      <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180611-0826"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.8.0.v20180611-0656"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.14.0.v20180611-0500"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.0.v20180512-1128"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.0.v20180518-2029"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.10.0.v20181206-0815"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.10.0.v20181206-1038"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.10.0.v20181206-0815"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.16.0.v20181206-1038"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.100.v20180822-1357"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.200.v20180922-1751"/>
       <unit id="org.eclipse.draw2d" version="3.10.100.201606061308"/>
       <unit id="org.eclipse.gef" version="3.11.0.201606061308"/>
-      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.8.0.v20180612-0940"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.14.0.v20180529-1157"/>
-      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.14.0.v20180131-0817"/>
+      <unit id="org.eclipse.m2m.qvt.oml.sdk.feature.group" version="3.9.1.v20181210-1559"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.16.0.v20181206-1055"/>
+      <unit id="org.eclipse.xsd.sdk.feature.group" version="2.16.0.v20181127-0852"/>
       <unit id="org.eclipse.emf.validation.sdk.feature.group" version="1.12.0.201805030717"/>
       <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.emf.workspace.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="1.12.0.201805221301"/>
       <unit id="org.eclipse.gmf.runtime.sdk.feature.group" version="1.12.0.201806010809"/>
-      <unit id="org.eclipse.uml2.sdk.feature.group" version="5.4.0.v20180604-1153"/>
-      <repository id="eclipse-photon" location="http://download.eclipse.org/releases/photon/"/>
+      <unit id="org.eclipse.uml2.sdk.feature.group" version="5.5.0.v20181203-1331"/>
+      <unit id="org.eclipse.equinox.transforms.hook" version="1.2.300.v20181116-1551"/>
+      <unit id="org.eclipse.equinox.transforms.xslt" version="1.0.500.v20180827-1235"/>
+      <repository id="eclipse-platform" location="http://download.eclipse.org/releases/2018-12/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.egit.feature.group" version="5.0.3.201809091024-r"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.0.3.201809091024-r"/>
-      <repository id="egit" location="http://download.eclipse.org/egit/updates-5.0.3"/>
+      <unit id="org.eclipse.egit.feature.group" version="5.2.0.201812061821-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.2.0.201812061821-r"/>
+      <repository id="egit" location="http://download.eclipse.org/egit/updates-5.2"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
@@ -35,7 +37,7 @@
       <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
       <unit id="com.google.guava.source" version="21.0.0.v20170206-1425"/>
       <unit id="javaewah" version="1.1.6.v20160919-1400"/>
-      <unit id="org.apache.commons.compress" version="1.15.0.v20180119-1613"/>
+      <unit id="org.apache.commons.compress" version="1.18.0.v20181121-2221"/>
       <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="org.kohsuke.args4j" version="2.33.0.v20160323-2218"/>
       <unit id="org.mockito" version="1.9.5.v201605172210"/>
@@ -44,16 +46,16 @@
       <unit id="org.hamcrest.integration" version="1.3.0.v201305210900"/>
       <unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
       <unit id="org.objenesis" version="1.0.0.v201505121915"/>
-      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/"/>
+      <repository id="orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.papyrus.sdk.feature.feature.group" version="4.0.0.201806130934"/>
-      <unit id="org.eclipse.papyrus.infra.gmfdiag.feature.feature.group" version="3.0.0.201806130934"/>
-      <unit id="org.eclipse.papyrus.infra.services.feature.feature.group" version="3.0.0.201806130934"/>
-      <unit id="org.eclipse.papyrus.views.properties.toolsmiths" version="2.0.2.201806131019"/>
-      <unit id="org.eclipse.papyrus.uml.assistants.feature.feature.group" version="4.0.0.201806131019"/>
-      <unit id="org.eclipse.papyrus.toolsmiths.feature.feature.group" version="1.2.0.201806131019"/>
-      <repository id="papyrus" location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/photon"/>
+      <unit id="org.eclipse.papyrus.sdk.feature.feature.group" version="4.2.0.201812120922"/>
+      <unit id="org.eclipse.papyrus.infra.gmfdiag.feature.feature.group" version="3.0.0.201812120922"/>
+      <unit id="org.eclipse.papyrus.infra.services.feature.feature.group" version="3.0.0.201812120922"/>
+      <unit id="org.eclipse.papyrus.views.properties.toolsmiths" version="2.0.2.201812121049"/>
+      <unit id="org.eclipse.papyrus.uml.assistants.feature.feature.group" version="4.0.0.201812121049"/>
+      <unit id="org.eclipse.papyrus.toolsmiths.feature.feature.group" version="1.2.0.201812121049"/>
+      <repository id="papyrus" location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2018-12"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.papyrus.compare.feature.feature.group" version="0.7.0.201810232321"/>

--- a/targetplatforms/r2018-12-release.tpd
+++ b/targetplatforms/r2018-12-release.tpd
@@ -1,6 +1,6 @@
-target "UML Light  Target Platform - Release" with source requirements
+target "UML Light Target Platform - 2018-12 Release" with source requirements
 
-location "http://download.eclipse.org/releases/photon/" eclipse-photon {
+location "http://download.eclipse.org/releases/2018-12/" eclipse-platform {
 	org.eclipse.platform.feature.group
 	org.eclipse.sdk.feature.group
 	org.eclipse.rcp.feature.group
@@ -18,15 +18,17 @@ location "http://download.eclipse.org/releases/photon/" eclipse-photon {
 	org.eclipse.gmf.runtime.notation.sdk.feature.group
 	org.eclipse.gmf.runtime.sdk.feature.group
 	org.eclipse.uml2.sdk.feature.group
+	org.eclipse.equinox.transforms.hook
+	org.eclipse.equinox.transforms.xslt
 }
 
-location "http://download.eclipse.org/egit/updates-5.0.3" egit {
+location "http://download.eclipse.org/egit/updates-5.2" egit {
 	org.eclipse.egit.feature.group
 	org.eclipse.jgit.feature.group
 }
 
 
-location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository/" {
+location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/" {
 	org.apache.commons.io
 	org.apache.commons.io.source
 	com.google.inject
@@ -44,7 +46,7 @@ location orbit "http://download.eclipse.org/tools/orbit/downloads/drops/R2018060
 	org.objenesis [1.0.0,2.0.0)
 }
 
-location papyrus "http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/photon" {
+location papyrus "http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2018-12" {
 	org.eclipse.papyrus.sdk.feature.feature.group
 	org.eclipse.papyrus.infra.gmfdiag.feature.feature.group
 	org.eclipse.papyrus.infra.services.feature.feature.group
@@ -52,7 +54,8 @@ location papyrus "http://download.eclipse.org/modeling/mdt/papyrus/updates/relea
 	org.eclipse.papyrus.uml.assistants.feature.feature.group
 	org.eclipse.papyrus.toolsmiths.feature.feature.group
 }
-// Using nightly version of Papyrus compare for now because the latest stable version has Photon incompatibilities 
+
+// Using nightly version of Papyrus compare for now because there is no stable version for 2018-12 
 location "http://download.eclipse.org/modeling/mdt/papyrus/components/compare/updates/nightly/latest/" {
 	org.eclipse.papyrus.compare.feature.feature.group 
 }


### PR DESCRIPTION
Rework the ‘photon’ release TP as 2018-12 and update the build to use the release target.