### PR TITLE
Fix #67 Filter state machine direct editors

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.core/plugin.xml
@@ -38,6 +38,15 @@
          </Priority>
       </editpolicyProvider>
    </extension>
+   <extension
+         point="org.eclipse.gmf.runtime.diagram.ui.editpartProviders">
+      <editpartProvider
+            class="org.eclipse.papyrus.umllight.core.internal.provider.StateMachineEditPartProvider">
+         <Priority
+               name="High">
+         </Priority>
+      </editpartProvider>
+   </extension>
     <extension
          name="UML Subset for UML Light"
          point="org.eclipse.papyrus.infra.properties.contexts">

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/editpart/UMLLightTransitionEditPart.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/editpart/UMLLightTransitionEditPart.java
@@ -1,0 +1,79 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal.editpart;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.draw2d.IFigure;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.emf.transaction.RunnableWithResult;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.Request;
+import org.eclipse.gef.requests.DirectEditRequest;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.statemachine.custom.edit.part.CustomTransitionEditPart;
+import org.eclipse.papyrus.uml.diagram.statemachine.edit.parts.TransitionNameEditPart;
+import org.eclipse.papyrus.umllight.core.internal.Activator;
+
+/**
+ * Custom edit-part for <em>UML Light</em> transitions. Customizations include:
+ * <ul>
+ * <li>direct edit targets the name label, not the guard</li>
+ * </ul>
+ */
+public class UMLLightTransitionEditPart extends CustomTransitionEditPart {
+
+	/**
+	 * Initializes me with the view that I control.
+	 * 
+	 * @param view my notation view
+	 */
+	public UMLLightTransitionEditPart(View view) {
+		super(view);
+	}
+
+	protected void performDirectEditRequest(Request request) {
+		EditPart editPart = this;
+		if (request instanceof DirectEditRequest) {
+			Point p = new Point(((DirectEditRequest) request).getLocation());
+			getFigure().translateToRelative(p);
+			IFigure fig = getFigure().findFigureAt(p);
+			editPart = (EditPart) getViewer().getVisualPartMap().get(fig);
+		}
+
+		if (editPart == this) {
+			try {
+				editPart = (EditPart) getEditingDomain().runExclusive(new RunnableWithResult.Impl<EditPart>() {
+
+					@Override
+					public void run() {
+						// Unlike the superclass, we edit the name, not the guard
+						@SuppressWarnings("unchecked")
+						List<? extends EditPart> children = getChildren();
+						setResult(children.stream().filter(TransitionNameEditPart.class::isInstance).findFirst()
+								.orElse(null));
+					}
+				});
+			} catch (InterruptedException e) {
+				IStatus failure = new Status(IStatus.ERROR, Activator.PLUGIN_ID, "Transaction interrupted", e);
+				Activator.getDefault().getLog().log(failure);
+			}
+
+			if (editPart != null) {
+				editPart.performRequest(request);
+			}
+		}
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/provider/StateMachineEditPartProvider.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/provider/StateMachineEditPartProvider.java
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal.provider;
+
+import org.eclipse.gmf.runtime.diagram.ui.services.editpart.AbstractEditPartProvider;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.statemachine.edit.parts.TransitionEditPart;
+import org.eclipse.papyrus.umllight.core.internal.UMLLightArchitecture;
+import org.eclipse.papyrus.umllight.core.internal.editpart.UMLLightTransitionEditPart;
+
+/**
+ * Custom edit-part provider for <em>UML Light</em> state machine diagrams.
+ */
+public class StateMachineEditPartProvider extends AbstractEditPartProvider {
+
+	/**
+	 * Initializes me.
+	 */
+	public StateMachineEditPartProvider() {
+		super();
+	}
+
+	@Override
+	protected Class<?> getEdgeEditPartClass(View view) {
+		if (TransitionEditPart.VISUAL_ID.equals(view.getType()) && UMLLightArchitecture.isUMLLight(view)) {
+			return UMLLightTransitionEditPart.class;
+		} else {
+			return super.getEdgeEditPartClass(view);
+		}
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/direct-edit.xslt
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/direct-edit.xslt
@@ -1,0 +1,16 @@
+ <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+     <!-- Add a constraint to the direct editor to apply only to UML models -->
+     <xsl:template match="DirectEditor">
+         <xsl:copy>
+             <xsl:attribute name="additionalConstraint">org.eclipse.papyrus.umllight.ui/org.eclipse.papyrus.umllight.ui.internal.directedit.IsNotUMLLightConstraint</xsl:attribute>
+             <xsl:apply-templates select="node()|@*"/>
+         </xsl:copy>
+     </xsl:template>
+     
+     <!-- Everything else -->
+     <xsl:template match="node()|@*">
+         <xsl:copy>
+             <xsl:apply-templates select="node()|@*"/>
+         </xsl:copy>
+     </xsl:template>
+ </xsl:stylesheet>

--- a/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/transforms.csv
+++ b/plugins/org.eclipse.papyrus.umllight.ui.simplification.transforms/transforms/transforms.csv
@@ -1,2 +1,4 @@
 #Bundle ID regex, Resource Path regex, resource path
 org\.eclipse\.papyrus\.infra\.nattable\.common,plugin\.xml,/transforms/nattable.xslt
+org\.eclipse\.papyrus\.uml\.textedit\.state\.xtext\.ui,plugin\.xml,/transforms/direct-edit.xslt
+org\.eclipse\.papyrus\.uml\.textedit\.transition\.xtext\.ui,plugin\.xml,/transforms/direct-edit.xslt

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -16,11 +16,13 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.infra.emf;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.papyrus.uml.properties;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.papyrus.infra.properties.ui;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.papyrus.uml.tools
+ org.eclipse.papyrus.uml.tools,
+ org.eclipse.papyrus.uml.xtext.integration.ui;bundle-version="[2.1.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true,
+ org.eclipse.papyrus.umllight.ui.internal.directedit;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.properties;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.widgets.editors;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true,

--- a/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
@@ -68,4 +68,35 @@
          </newWizardShortcut>
       </perspectiveExtension>
    </extension>
+
+   <extension
+         point="org.eclipse.papyrus.infra.gmfdiag.extensionpoints.editors.DirectEditor">
+      <DirectEditor
+            additionalConstraint="org.eclipse.papyrus.umllight.ui.internal.directedit.IsUMLLightConstraint"
+            contributor="EclipseSource Munich"
+            language="UML Light State Name Editor"
+            objectToEdit="org.eclipse.uml2.uml.State">
+         <popupeditor
+               editorConfiguration="org.eclipse.papyrus.umllight.ui.internal.directedit.NamedElementDirectEditorConfiguration">
+         </popupeditor>
+         <Priority
+               name="High">
+         </Priority>         
+      </DirectEditor>
+   </extension>
+   <extension
+         point="org.eclipse.papyrus.infra.gmfdiag.extensionpoints.editors.DirectEditor">
+      <DirectEditor
+            additionalConstraint="org.eclipse.papyrus.umllight.ui.internal.directedit.IsUMLLightConstraint"
+            contributor="EclipseSource Munich"
+            language="UML Light Transition Name Editor"
+            objectToEdit="org.eclipse.uml2.uml.Transition">
+         <popupeditor
+               editorConfiguration="org.eclipse.papyrus.umllight.ui.internal.directedit.NamedElementDirectEditorConfiguration">
+         </popupeditor>
+         <Priority
+               name="High">
+         </Priority>         
+      </DirectEditor>
+   </extension>
 </plugin>

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/IsNotUMLLightConstraint.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/IsNotUMLLightConstraint.java
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.directedit;
+
+import org.eclipse.papyrus.infra.gmfdiag.extensionpoints.editors.configuration.IDirectEditorConstraint;
+
+/**
+ * A direct editor constraint that checks whether the contextual element is
+ * <strong>not</strong> in a <em>UML Light</em> model.
+ */
+public class IsNotUMLLightConstraint implements IDirectEditorConstraint {
+
+	private final IsUMLLightConstraint isUMLLight = new IsUMLLightConstraint();
+
+	/**
+	 * Initializes me.
+	 */
+	public IsNotUMLLightConstraint() {
+		super();
+	}
+
+	@Override
+	public String getLabel() {
+		return "In UML Model";
+	}
+
+	@Override
+	public boolean appliesTo(Object selection) {
+		return !isUMLLight.appliesTo(selection);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/IsUMLLightConstraint.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/IsUMLLightConstraint.java
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.directedit;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.papyrus.infra.emf.utils.EMFHelper;
+import org.eclipse.papyrus.infra.gmfdiag.extensionpoints.editors.configuration.IDirectEditorConstraint;
+import org.eclipse.papyrus.umllight.core.internal.UMLLightArchitecture;
+
+/**
+ * A direct editor constraint that checks whether the contextual element is in a
+ * <em>UML Light</em> model.
+ */
+public class IsUMLLightConstraint implements IDirectEditorConstraint {
+
+	/**
+	 * Initializes me.
+	 */
+	public IsUMLLightConstraint() {
+		super();
+	}
+
+	@Override
+	public String getLabel() {
+		return "In UML Light Model";
+	}
+
+	@Override
+	public boolean appliesTo(Object selection) {
+		EObject object = EMFHelper.getEObject(selection);
+
+		return (object != null) && UMLLightArchitecture.isUMLLight(object);
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/NamedElementDirectEditorConfiguration.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/directedit/NamedElementDirectEditorConfiguration.java
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.directedit;
+
+import org.eclipse.gmf.runtime.common.ui.services.parser.IParser;
+import org.eclipse.papyrus.infra.gmfdiag.extensionpoints.editors.configuration.AbstractBasicDirectEditorConfiguration;
+import org.eclipse.papyrus.uml.diagram.common.parser.NamedElementLabelParser;
+import org.eclipse.uml2.uml.NamedElement;
+
+/**
+ * Simple direct-editor configuration for {@link NamedElement}s that just edits
+ * their names.
+ */
+public class NamedElementDirectEditorConfiguration extends AbstractBasicDirectEditorConfiguration {
+
+	/**
+	 * Initializes me.
+	 */
+	public NamedElementDirectEditorConfiguration() {
+		super();
+	}
+
+	@Override
+	public IParser createDirectEditorParser() {
+		return new NamedElementLabelParser();
+	}
+
+}


### PR DESCRIPTION
Prefer a simple name direct editor for states and transitions.

Ensure that direct-edit invocation on a transition targets the name label, not the guard label.

Inject a constraint into the state and transition direct-editor configuration registrations that restricts their applicability
to non-UML-Light models only.