### PR TITLE
Fix #56 Elide the state machine region

### DIFF
--- a/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
+++ b/plugins/org.eclipse.papyrus.umllight.core/resource/creationmenu/UMLLightNewChild.creationmenumodel
@@ -75,19 +75,19 @@
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="StateMachine" role="packagedElement" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.StateMachine"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Initial State" role="subvertex" displayAllRoles="false">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Initial State" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="../types/UMLLight.elementtypesconfigurations#_ICEUQO2cEeivp-E0jxzQrg"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Final State" role="subvertex" displayAllRoles="false">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Final State" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.FinalState"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Choice" role="subvertex" displayAllRoles="false">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Choice" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="../types/UMLLight.elementtypesconfigurations#_MBXwgO2eEeivp-E0jxzQrg"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Junction" role="subvertex" displayAllRoles="false">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Junction" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:SpecializationTypeConfiguration" href="../types/UMLLight.elementtypesconfigurations#_MReCAO2eEeivp-E0jxzQrg"/>
   </menu>
-  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="State" role="subvertex" displayAllRoles="false">
+  <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="State" displayAllRoles="false">
     <elementType xsi:type="elementtypesconfigurations:MetamodelTypeConfiguration" href="platform:/plugin/org.eclipse.papyrus.uml.service.types/model/uml.elementtypesconfigurations#org.eclipse.papyrus.uml.State"/>
   </menu>
   <menu xsi:type="ElementCreationMenuModel:CreationMenu" label="Initial Node" displayAllRoles="false">

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/PseudostateAdvice.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/PseudostateAdvice.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2018 Christian W. Damus and others.
+ * Copyright (c) 2018, 2019 Christian W. Damus and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,6 +17,9 @@ import org.eclipse.gmf.runtime.emf.type.core.IElementMatcher;
 import org.eclipse.gmf.runtime.emf.type.core.IHintedType;
 import org.eclipse.gmf.runtime.emf.type.core.edithelper.AbstractEditHelperAdvice;
 import org.eclipse.gmf.runtime.emf.type.core.requests.ConfigureRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.CreateElementRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.GetEditContextRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.IEditCommandRequest;
 import org.eclipse.gmf.runtime.emf.type.core.requests.SetRequest;
 import org.eclipse.uml2.uml.Pseudostate;
 import org.eclipse.uml2.uml.PseudostateKind;
@@ -27,11 +30,30 @@ import org.eclipse.uml2.uml.UMLPackage;
  */
 public class PseudostateAdvice extends AbstractEditHelperAdvice {
 
+	private final RegionElisionHelper region = new RegionElisionHelper();
+
 	/**
 	 * Initializes me.
 	 */
 	public PseudostateAdvice() {
 		super();
+	}
+
+	@Override
+	protected ICommand getBeforeEditContextCommand(GetEditContextRequest request) {
+		return region.getBeforeEditContextCommand(request);
+	}
+
+	public void configureRequest(IEditCommandRequest request) {
+		super.configureRequest(request);
+
+		if (request instanceof CreateElementRequest) {
+			configureCreateRequest((CreateElementRequest) request);
+		}
+	}
+
+	protected void configureCreateRequest(CreateElementRequest request) {
+		region.configureCreateRequest(request);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/RegionElisionHelper.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/RegionElisionHelper.java
@@ -1,0 +1,114 @@
+/*****************************************************************************
+ * Copyright (c) 2019 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal.advice;
+
+import static org.eclipse.papyrus.uml.service.types.utils.ElementUtil.isTypeOf;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.gmf.runtime.common.core.command.ICommand;
+import org.eclipse.gmf.runtime.emf.core.util.PackageUtil;
+import org.eclipse.gmf.runtime.emf.type.core.IElementType;
+import org.eclipse.gmf.runtime.emf.type.core.commands.GetEditContextCommand;
+import org.eclipse.gmf.runtime.emf.type.core.requests.CreateElementRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.DestroyElementRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.GetEditContextRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.IEditCommandRequest;
+import org.eclipse.papyrus.uml.service.types.element.UMLElementTypes;
+import org.eclipse.uml2.uml.Region;
+import org.eclipse.uml2.uml.StateMachine;
+import org.eclipse.uml2.uml.Transition;
+import org.eclipse.uml2.uml.UMLPackage;
+import org.eclipse.uml2.uml.Vertex;
+
+/**
+ * An edit-advice helper for the elision of {@link Region}s in the UI context of
+ * the editor (<em>Model Explorer</em> tree, diagram, etc.).
+ */
+final class RegionElisionHelper {
+
+	/**
+	 * Initializes me
+	 */
+	RegionElisionHelper() {
+		super();
+	}
+
+	/**
+	 * Creates advice for an edit-context {@code request}.
+	 * 
+	 * @param request an edit-context request
+	 * @return my advice, or {@code null} if I provide none
+	 */
+	ICommand getBeforeEditContextCommand(GetEditContextRequest request) {
+		GetEditContextCommand result = null;
+
+		Object context = request.getEditContext();
+		if (context instanceof StateMachine) {
+			StateMachine stateMachine = (StateMachine) context;
+
+			if (isRequestForRegionOwnedElement(request.getEditCommandRequest())
+					&& !stateMachine.getRegions().isEmpty()) {
+
+				context = stateMachine.getRegions().get(0);
+				result = new GetEditContextCommand(request);
+				result.setEditContext(context);
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Configures the given create {@code request}, if appropriate.
+	 * 
+	 * @param request a create request to configure
+	 * 
+	 * @return {@code true} if I configured it and it probably shouldn't be
+	 *         configured again by another helper; {@code false} otherwise
+	 */
+	boolean configureCreateRequest(CreateElementRequest request) {
+		boolean result = (request.getContainmentFeature() == null) && isRequestForRegionOwnedElement(request);
+
+		if (result) {
+			// Set the containment reference that we had to leave unset in order to pass
+			// the New Child framework's filtering
+			request.initializeContainmentFeature(
+					PackageUtil.findFeature(UMLPackage.Literals.REGION, request.getElementType().getEClass()));
+		}
+
+		return result;
+	}
+
+	/**
+	 * Query whether a {@code request} is for creation or deletion of a
+	 * {@link Region}-owned element in the context of a {@link StateMachine}.
+	 * 
+	 * @param request a request
+	 * @return whether it is a create or destroy request for a region-owned element
+	 */
+	boolean isRequestForRegionOwnedElement(IEditCommandRequest request) {
+		boolean result = false;
+
+		if (request instanceof CreateElementRequest) {
+			CreateElementRequest create = (CreateElementRequest) request;
+			IElementType type = create.getElementType();
+			result = isTypeOf(type, UMLElementTypes.VERTEX) || isTypeOf(type, UMLElementTypes.TRANSITION);
+		} else if (request instanceof DestroyElementRequest) {
+			DestroyElementRequest destroy = (DestroyElementRequest) request;
+			EObject element = destroy.getElementToDestroy();
+			result = (element instanceof Vertex) || (element instanceof Transition);
+		}
+
+		return result;
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/StateMachineAdvice.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/advice/StateMachineAdvice.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2018 Christian W. Damus and others.
+ * Copyright (c) 2018, 2019 Christian W. Damus and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -22,6 +22,7 @@ import org.eclipse.gmf.runtime.common.core.command.ICommand;
 import org.eclipse.gmf.runtime.emf.commands.core.command.AbstractTransactionalCommand;
 import org.eclipse.gmf.runtime.emf.type.core.requests.ConfigureRequest;
 import org.eclipse.gmf.runtime.emf.type.core.requests.CreateElementRequest;
+import org.eclipse.gmf.runtime.emf.type.core.requests.GetEditContextRequest;
 import org.eclipse.papyrus.uml.service.types.element.UMLElementTypes;
 import org.eclipse.uml2.uml.StateMachine;
 import org.eclipse.uml2.uml.UMLPackage;
@@ -32,11 +33,23 @@ import org.eclipse.uml2.uml.util.UMLSwitch;
  */
 public class StateMachineAdvice extends AbstractNewChildAdvice {
 
+	private final RegionElisionHelper region = new RegionElisionHelper();
+
 	/**
 	 * Initializes me.
 	 */
 	public StateMachineAdvice() {
 		super();
+	}
+
+	@Override
+	protected ICommand getBeforeEditContextCommand(GetEditContextRequest request) {
+		return region.getBeforeEditContextCommand(request);
+	}
+
+	@Override
+	protected void configureCreateRequest(CreateElementRequest request) {
+		region.configureCreateRequest(request);
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/editpart/UMLLightRegionEditPart.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/editpart/UMLLightRegionEditPart.java
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Copyright (c) 2019 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.core.internal.editpart;
+
+import org.eclipse.gef.DragTracker;
+import org.eclipse.gef.EditPart;
+import org.eclipse.gef.Request;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.statemachine.custom.edit.part.CustomRegionEditPart;
+import org.eclipse.papyrus.uml.diagram.statemachine.custom.policies.CustomRegionDragTracker;
+import org.eclipse.uml2.uml.Region;
+
+/**
+ * A customization of the {@link Region} view controller for <em>UML Light</em>.
+ */
+public class UMLLightRegionEditPart extends CustomRegionEditPart {
+
+	/**
+	 * Initializes me with my notation view.
+	 * 
+	 * @param view my region view
+	 */
+	public UMLLightRegionEditPart(View view) {
+		super(view);
+	}
+
+	/**
+	 * Forward selection from the region to the state machine, as in the <em>UML
+	 * Light</em> context we aren't interested in the region as an element.
+	 */
+	@Override
+	public DragTracker getDragTracker(Request request) {
+		return new CustomRegionDragTracker(this) {
+
+			@Override
+			protected void setSourceEditPart(EditPart part) {
+				if (part == UMLLightRegionEditPart.this) {
+					// Select the state machine, itself
+					part = part.getParent().getParent();
+				}
+				super.setSourceEditPart(part);
+			}
+
+		};
+	}
+
+}

--- a/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/provider/StateMachineEditPartProvider.java
+++ b/plugins/org.eclipse.papyrus.umllight.core/src/org/eclipse/papyrus/umllight/core/internal/provider/StateMachineEditPartProvider.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2018 Christian W. Damus and others.
+ * Copyright (c) 2018, 2019 Christian W. Damus and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,8 +13,10 @@ package org.eclipse.papyrus.umllight.core.internal.provider;
 
 import org.eclipse.gmf.runtime.diagram.ui.services.editpart.AbstractEditPartProvider;
 import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.diagram.statemachine.edit.parts.RegionEditPart;
 import org.eclipse.papyrus.uml.diagram.statemachine.edit.parts.TransitionEditPart;
 import org.eclipse.papyrus.umllight.core.internal.UMLLightArchitecture;
+import org.eclipse.papyrus.umllight.core.internal.editpart.UMLLightRegionEditPart;
 import org.eclipse.papyrus.umllight.core.internal.editpart.UMLLightTransitionEditPart;
 
 /**
@@ -27,6 +29,15 @@ public class StateMachineEditPartProvider extends AbstractEditPartProvider {
 	 */
 	public StateMachineEditPartProvider() {
 		super();
+	}
+
+	@Override
+	protected Class<?> getNodeEditPartClass(View view) {
+		if (RegionEditPart.VISUAL_ID.equals(view.getType()) && UMLLightArchitecture.isUMLLight(view)) {
+			return UMLLightRegionEditPart.class;
+		} else {
+			return super.getNodeEditPartClass(view);
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.papyrus.umllight.ui/META-INF/MANIFEST.MF
@@ -17,12 +17,15 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.papyrus.uml.properties;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.papyrus.infra.properties.ui;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.papyrus.uml.tools,
- org.eclipse.papyrus.uml.xtext.integration.ui;bundle-version="[2.1.0,3.0.0)"
+ org.eclipse.papyrus.uml.xtext.integration.ui;bundle-version="[2.1.0,3.0.0)",
+ org.eclipse.papyrus.uml.modelexplorer;bundle-version="[2.0.100,3.0.0)",
+ org.eclipse.papyrus.views.modelexplorer;bundle-version="[3.0.100,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.papyrus.umllight.core
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.papyrus.umllight.ui.internal;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.directedit;x-internal:=true,
+ org.eclipse.papyrus.umllight.ui.internal.facet;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.properties;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.widgets.editors;x-internal:=true,
  org.eclipse.papyrus.umllight.ui.internal.wizard;x-internal:=true,

--- a/plugins/org.eclipse.papyrus.umllight.ui/build.properties
+++ b/plugins/org.eclipse.papyrus.umllight.ui/build.properties
@@ -5,6 +5,7 @@ bin.includes = META-INF/,\
                plugin.xml,\
                icons/,\
                about.html,\
-               OSGI-INF/
+               OSGI-INF/,\
+               resources/
 bin.excludes = **/*.pxd/**,\
                **/*.psd

--- a/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
+++ b/plugins/org.eclipse.papyrus.umllight.ui/plugin.xml
@@ -99,4 +99,12 @@
          </Priority>         
       </DirectEditor>
    </extension>
+   
+   <extension
+         point="org.eclipse.papyrus.emf.facet.util.emf.core.modeldeclaration">
+      <modeldeclaration
+            file="resources/facet/UMLLight.custom">
+      </modeldeclaration>
+   </extension>
+   
 </plugin>

--- a/plugins/org.eclipse.papyrus.umllight.ui/resources/facet/UMLLight.custom
+++ b/plugins/org.eclipse.papyrus.umllight.ui/resources/facet/UMLLight.custom
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<custom:Customization xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:custom="http://www.eclipse.org/papyrus/emf/facet/custom/0.2.incubation/custom" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:efacet="http://www.eclipse.org/papyrus/emf/facet/efacet/0.2.incubation/efacet" xmlns:javaQuery="http://www.eclipse.org/papyrus/emf/facet/query/java/0.2.incubation/javaquery" xmlns:oclQuery="http://www.eclipse.org/papyrus/emf/facet/query/ocl/0.3.incubation/oclquery" name="UMLLight" documentation="Simplifications of the Model Explorer presentation for UML Light." mustBeLoadedByDefault="true" rank="10">
+  <eClassifiers xsi:type="custom:EClassCustomization" name="LightStateMachine" documentation="A state machine in an UML Light model.">
+    <extendedMetaclass href="http://www.eclipse.org/uml2/5.0.0/UML#//StateMachine"/>
+    <facetElements xsi:type="efacet:FacetReference" name="regionComments" upperBound="-1" volatile="true" transient="true" derived="true">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Comment"/>
+      <query xsi:type="oclQuery:OclQuery" oclExpression="self.region.ownedComment">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StateMachine"/>
+      </query>
+    </facetElements>
+    <facetElements xsi:type="efacet:FacetReference" name="regionConstraints" upperBound="-1" volatile="true" transient="true" derived="true">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Constraint"/>
+      <query xsi:type="oclQuery:OclQuery" oclExpression="self.region.ownedRule">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StateMachine"/>
+      </query>
+    </facetElements>
+    <facetElements xsi:type="efacet:FacetReference" name="vertices" upperBound="-1" volatile="true" transient="true" derived="true">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Vertex"/>
+      <query xsi:type="oclQuery:OclQuery" oclExpression="self.region.subvertex">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StateMachine"/>
+      </query>
+    </facetElements>
+    <facetElements xsi:type="efacet:FacetReference" name="transitions" upperBound="-1" volatile="true" transient="true" derived="true">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Transition"/>
+      <query xsi:type="oclQuery:OclQuery" oclExpression="self.region.transition">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//StateMachine"/>
+      </query>
+    </facetElements>
+    <facetOperations name="umlLightVisibleReferences" upperBound="-1">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/emf/2002/Ecore#//EReference"/>
+      <query xsi:type="javaQuery:JavaQuery" canBeCached="true" implementationClassName="org.eclipse.papyrus.umllight.ui.internal.facet.UMLLightVisibleReferencesQuery"/>
+      <override xsi:type="efacet:FacetOperation" href="platform:/plugin/org.eclipse.papyrus.uml.modelexplorer/resource/SimpleUML.custom#//Element/DisplayOnlyContainmentReferences"/>
+    </facetOperations>
+    <extendedFacets href="platform:/plugin/org.eclipse.papyrus.uml.modelexplorer/resource/SimpleUML.custom#//Element"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="custom:EClassCustomization" name="RegionOwnedElement" documentation="An element that is in a region of a state machine." conformanceTypedElement="//RegionOwnedElement/isInRegion">
+    <extendedMetaclass href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+    <facetOperations name="isInRegion" lowerBound="1" documentation="Query whether the element is owned by a state machine region.">
+      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+      <query xsi:type="oclQuery:OclQuery" canBeCached="true" oclExpression="self.owner.oclIsKindOf(Region)">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+      </query>
+    </facetOperations>
+    <facetOperations name="impliedOwner" lowerBound="1" documentation="The implied owner of the element, which is its owning region's state machine.">
+      <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+      <eParameters name="eStructuralFeature">
+        <eType xsi:type="ecore:EClass" href="http://www.eclipse.org/emf/2002/Ecore#//ETypedElement"/>
+      </eParameters>
+      <query xsi:type="oclQuery:OclQuery" oclExpression="self.owner.oclAsType(Region).stateMachine">
+        <context xsi:type="ecore:EClass" href="http://www.eclipse.org/uml2/5.0.0/UML#//Element"/>
+      </query>
+      <override xsi:type="efacet:FacetOperation" href="platform:/plugin/org.eclipse.papyrus.emf.facet.custom.ui/resources/customproperties.efacet#//CustomizedEObject/parent"/>
+    </facetOperations>
+    <extendedFacets href="platform:/plugin/org.eclipse.papyrus.emf.facet.custom.ui/resources/customproperties.efacet#//CustomizedEObject"/>
+  </eClassifiers>
+</custom:Customization>

--- a/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/facet/UMLLightVisibleReferencesQuery.java
+++ b/plugins/org.eclipse.papyrus.umllight.ui/src/org/eclipse/papyrus/umllight/ui/internal/facet/UMLLightVisibleReferencesQuery.java
@@ -1,0 +1,55 @@
+/*****************************************************************************
+ * Copyright (c) 2019 Christian W. Damus and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *		Christian W. Damus - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.umllight.ui.internal.facet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.papyrus.emf.facet.efacet.core.IFacetManager;
+import org.eclipse.papyrus.emf.facet.efacet.core.exception.DerivedTypedElementException;
+import org.eclipse.papyrus.emf.facet.query.java.core.IParameterValueList2;
+import org.eclipse.papyrus.uml.modelexplorer.queries.GetVisibleUMLReferencesQuery;
+import org.eclipse.uml2.uml.UMLPackage;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Facet query determining the restricted set of references to be followed to
+ * construct the content tree in the <em>Model Explorer</em> view.
+ */
+public class UMLLightVisibleReferencesQuery extends GetVisibleUMLReferencesQuery {
+
+	private static final Set<EReference> EXCLUDED_REFERENCES = ImmutableSet
+			.of(UMLPackage.Literals.STATE_MACHINE__REGION, UMLPackage.Literals.STATE__REGION);
+
+	/**
+	 * Initializes me.
+	 */
+	public UMLLightVisibleReferencesQuery() {
+		super();
+	}
+
+	@Override
+	public List<EReference> evaluate(EObject source, IParameterValueList2 parameterValues, IFacetManager facetManager)
+			throws DerivedTypedElementException {
+
+		List<EReference> result = new ArrayList<EReference>(super.evaluate(source, parameterValues, facetManager));
+
+		result.removeAll(EXCLUDED_REFERENCES);
+
+		return result;
+	}
+
+}


### PR DESCRIPTION
Hoist the contents of the state machine’s region into the state machine in the Model Explorer.  Forward selection
of the region edit-part in the diagram to the state machine.